### PR TITLE
chore: remove redundant `--strict` option from `swiftlint`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,4 +23,3 @@ repos:
         args:
           - "--fix"
           - "--format"
-          - "--strict"


### PR DESCRIPTION
## What's Changed

`--strict` is ignored with `--fix`.

Closes #25.
