### PR TITLE
chore: add missing write permission to push built Docker images

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -59,6 +59,8 @@ jobs:
     name: Ubuntu Swift 5.10
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: write
     env:
       DOCKER_VOLUME_PREFIX: .docker/
     steps:


### PR DESCRIPTION
## What's Changed

Override permission in the `docker` job.

Closes #37.
