### PR TITLE
GH-16: Add support for List data types

### DIFF
--- a/Arrow/Sources/Arrow/ArrowArray.swift
+++ b/Arrow/Sources/Arrow/ArrowArray.swift
@@ -113,6 +113,8 @@ public class ArrowArrayHolderImpl: ArrowArrayHolder {
             return try ArrowArrayHolderImpl(BinaryArray(with))
         case .strct:
             return try ArrowArrayHolderImpl(StructArray(with))
+        case .list:
+            return try ArrowArrayHolderImpl(ListArray(with))
         default:
             throw ArrowError.invalid("Array not found for type: \(arrowType)")
         }
@@ -322,6 +324,72 @@ public class StructArray: ArrowArray<[Any?]> {
         }
 
         output += "}"
+        return output
+    }
+}
+
+public class ListArray: ArrowArray<[Any?]> {
+    public private(set) var values: ArrowArrayHolder?
+
+    public required init(_ arrowData: ArrowData) throws {
+        try super.init(arrowData)
+        guard arrowData.children.count == 1 else {
+            throw ArrowError.invalid("List array must have exactly one child")
+        }
+
+        guard let listType = arrowData.type as? ArrowTypeList else {
+            throw ArrowError.invalid("Expected ArrowTypeList")
+        }
+
+        self.values = try ArrowArrayHolderImpl.loadArray(
+            listType.elementType,
+            with: arrowData.children[0]
+        )
+    }
+
+    public override subscript(_ index: UInt) -> [Any?]? {
+        guard let values = self.values else { return nil }
+
+        if self.arrowData.isNull(index) {
+            return nil
+        }
+
+        let offsets = self.arrowData.buffers[1]
+        let offsetIndex = Int(index) * MemoryLayout<Int32>.stride
+
+        let startOffset = offsets.rawPointer.advanced(by: offsetIndex).load(as: Int32.self)
+        let endOffset = offsets.rawPointer.advanced(by: offsetIndex + MemoryLayout<Int32>.stride).load(as: Int32.self)
+
+        var items = [Any?]()
+        for i in startOffset..<endOffset {
+            items.append(values.array.asAny(UInt(i)))
+        }
+
+        return items
+    }
+
+    public override func asString(_ index: UInt) -> String {
+        guard let list = self[index] else {
+            return "null"
+        }
+
+        var output = "["
+
+        for (i, item) in list.enumerated() {
+            if i > 0 {
+                output.append(",")
+            }
+
+            if item == nil {
+                output.append("null")
+            } else if let asStringItem = item as? AsString {
+                output.append(asStringItem.asString(0))
+            } else {
+                output.append("\(item!)")
+            }
+        }
+
+        output.append("]")
         return output
     }
 }

--- a/Arrow/Sources/Arrow/ArrowArrayBuilder.swift
+++ b/Arrow/Sources/Arrow/ArrowArrayBuilder.swift
@@ -125,7 +125,7 @@ public class StructArrayBuilder: ArrowArrayBuilder<StructBufferBuilder, StructAr
     public init(_ fields: [ArrowField], builders: [any ArrowArrayHolderBuilder]) throws {
         self.fields = fields
         self.builders = builders
-        try super.init(ArrowNestedType(ArrowType.ArrowStruct, fields: fields))
+        try super.init(ArrowTypeStruct(ArrowType.ArrowStruct, fields: fields))
         self.bufferBuilder.initializeTypeInfo(fields)
     }
 
@@ -137,7 +137,7 @@ public class StructArrayBuilder: ArrowArrayBuilder<StructBufferBuilder, StructAr
         }
 
         self.builders = builders
-        try super.init(ArrowNestedType(ArrowType.ArrowStruct, fields: fields))
+        try super.init(ArrowTypeStruct(ArrowType.ArrowStruct, fields: fields))
     }
 
     public override func append(_ values: [Any?]?) {
@@ -165,6 +165,31 @@ public class StructArrayBuilder: ArrowArrayBuilder<StructBufferBuilder, StructAr
                                       length: self.length)
         let structArray = try StructArray(arrowData)
         return structArray
+    }
+}
+
+public class ListArrayBuilder: ArrowArrayBuilder<ListBufferBuilder, ListArray> {
+    let valueBuilder: any ArrowArrayHolderBuilder
+
+    public override init(_ elementType: ArrowType) throws {
+        self.valueBuilder = try ArrowArrayBuilders.loadBuilder(arrowType: elementType)
+        try super.init(ArrowTypeList(elementType))
+    }
+
+    public override func append(_ values: [Any?]?) {
+        self.bufferBuilder.append(values)
+        if let vals = values {
+            for val in vals {
+                self.valueBuilder.appendAny(val)
+            }
+        }
+    }
+
+    public override func finish() throws -> ListArray {
+        let buffers = self.bufferBuilder.finish()
+        let childData = try valueBuilder.toHolder().array.arrowData
+        let arrowData = try ArrowData(self.type, buffers: buffers, children: [childData], nullCount: self.nullCount, length: self.length)
+        return try ListArray(arrowData)
     }
 }
 
@@ -279,6 +304,16 @@ public class ArrowArrayBuilders {
                 throw ArrowError.invalid("Expected arrow type for \(arrowType.id) not found")
             }
             return try Time64ArrayBuilder(timeType.unit)
+        case .list:
+            guard let listType = arrowType as? ArrowTypeList else {
+                throw ArrowError.invalid("Expected ArrowTypeList for \(arrowType.id)")
+            }
+            return try ListArrayBuilder(listType.elementType)
+        case .strct:
+            guard let structType = arrowType as? ArrowTypeStruct else {
+                throw ArrowError.invalid("Expected ArrowStructType for \(arrowType.id)")
+            }
+            return try StructArrayBuilder(structType.fields)
         default:
             throw ArrowError.unknownType("Builder not found for arrow type: \(arrowType.id)")
         }
@@ -337,5 +372,13 @@ public class ArrowArrayBuilders {
 
     public static func loadTime64ArrayBuilder(_ unit: ArrowTime64Unit) throws -> Time64ArrayBuilder {
         return try Time64ArrayBuilder(unit)
+    }
+
+    public static func loadStructArrayBuilder(_ fields: [ArrowField]) throws -> StructArrayBuilder {
+        return try StructArrayBuilder(fields)
+    }
+
+    public static func loadListArrayBuilder(_ elementType: ArrowType) throws -> ListArrayBuilder {
+        return try ListArrayBuilder(elementType)
     }
 }

--- a/Arrow/Sources/Arrow/ArrowReaderHelper.swift
+++ b/Arrow/Sources/Arrow/ArrowReaderHelper.swift
@@ -136,6 +136,23 @@ func makeStructHolder(
     }
 }
 
+func makeListHolder(
+    _ field: ArrowField,
+    buffers: [ArrowBuffer],
+    nullCount: UInt,
+    children: [ArrowData],
+    rbLength: UInt
+) -> Result<ArrowArrayHolder, ArrowError> {
+    do {
+        let arrowData = try ArrowData(field.type, buffers: buffers, children: children, nullCount: nullCount, length: rbLength)
+        return .success(ArrowArrayHolderImpl(try ListArray(arrowData)))
+    } catch let error as ArrowError {
+        return .failure(error)
+    } catch {
+        return .failure(.unknownError("\(error)"))
+    }
+}
+
 func makeArrayHolder(
     _ field: org_apache_arrow_flatbuf_Field,
     buffers: [ArrowBuffer],
@@ -188,6 +205,8 @@ func makeArrayHolder( // swiftlint:disable:this cyclomatic_complexity
         return makeTimeHolder(field, buffers: buffers, nullCount: nullCount)
     case .strct:
         return makeStructHolder(field, buffers: buffers, nullCount: nullCount, children: children!, rbLength: rbLength)
+    case .list:
+        return makeListHolder(field, buffers: buffers, nullCount: nullCount, children: children!, rbLength: rbLength)
     default:
         return .failure(.unknownType("Type \(typeId) currently not supported"))
     }
@@ -204,15 +223,6 @@ func makeBuffer(_ buffer: org_apache_arrow_flatbuf_Buffer, fileData: Data,
 func isFixedPrimitive(_ type: org_apache_arrow_flatbuf_Type_) -> Bool {
     switch type {
     case .int, .bool, .floatingpoint, .date, .time:
-        return true
-    default:
-        return false
-    }
-}
-
-func isNestedType(_ type: org_apache_arrow_flatbuf_Type_) -> Bool {
-    switch type {
-    case .struct_:
         return true
     default:
         return false
@@ -271,7 +281,13 @@ func findArrowType( // swiftlint:disable:this cyclomatic_complexity function_bod
                 ArrowField(childField.name ?? "", type: childType, isNullable: childField.nullable))
         }
 
-        return ArrowNestedType(ArrowType.ArrowStruct, fields: fields)
+        return ArrowTypeStruct(ArrowType.ArrowStruct, fields: fields)
+    case .list:
+        guard field.childrenCount == 1, let childField = field.children(at: 0) else {
+            return ArrowType(ArrowType.ArrowUnknown)
+        }
+        let childType = findArrowType(childField)
+        return ArrowTypeList(childType)
     default:
         return ArrowType(ArrowType.ArrowUnknown)
     }

--- a/Arrow/Sources/Arrow/ArrowType.swift
+++ b/Arrow/Sources/Arrow/ArrowType.swift
@@ -122,11 +122,20 @@ public class ArrowTypeTime64: ArrowType {
     }
 }
 
-public class ArrowNestedType: ArrowType {
+public class ArrowTypeStruct: ArrowType {
     let fields: [ArrowField]
     public init(_ info: ArrowType.Info, fields: [ArrowField]) {
         self.fields = fields
         super.init(info)
+    }
+}
+
+public class ArrowTypeList: ArrowType {
+    let elementType: ArrowType
+
+    public init(_ elementType: ArrowType) {
+        self.elementType = elementType
+        super.init(ArrowType.ArrowList)
     }
 }
 
@@ -151,6 +160,7 @@ public class ArrowType {
     public static let ArrowTime32 = Info.timeInfo(ArrowTypeId.time32)
     public static let ArrowTime64 = Info.timeInfo(ArrowTypeId.time64)
     public static let ArrowStruct = Info.complexInfo(ArrowTypeId.strct)
+    public static let ArrowList = Info.complexInfo(ArrowTypeId.list)
 
     public init(_ info: ArrowType.Info) {
         self.info = info
@@ -274,7 +284,7 @@ public class ArrowType {
             return MemoryLayout<Int8>.stride
         case .string:
             return MemoryLayout<Int8>.stride
-        case .strct:
+        case .strct, .list:
             return 0
         default:
             fatalError("Stride requested for unknown type: \(self)")
@@ -324,6 +334,20 @@ public class ArrowType {
                 return "z"
             case ArrowTypeId.string:
                 return "u"
+            case ArrowTypeId.strct:
+                if let structType = self as? ArrowTypeStruct {
+                    var format = "+s"
+                    for field in structType.fields {
+                        format += try field.type.cDataFormatId
+                    }
+                    return format
+                }
+                throw ArrowError.invalid("Invalid struct type")
+            case ArrowTypeId.list:
+                if let listType = self as? ArrowTypeList {
+                    return "+l" + (try listType.elementType.cDataFormatId)
+                }
+                throw ArrowError.invalid("Invalid list type")
             default:
                 throw ArrowError.notImplemented
             }

--- a/Arrow/Sources/Arrow/ArrowWriter.swift
+++ b/Arrow/Sources/Arrow/ArrowWriter.swift
@@ -72,7 +72,7 @@ public class ArrowWriter { // swiftlint:disable:this type_body_length
 
     private func writeField(_ fbb: inout FlatBufferBuilder, field: ArrowField) -> Result<Offset, ArrowError> {
         var fieldsOffset: Offset?
-        if let nestedField = field.type as? ArrowNestedType {
+        if let nestedField = field.type as? ArrowTypeStruct {
             var offsets = [Offset]()
             for field in nestedField.fields {
                 switch writeField(&fbb, field: field) {
@@ -169,7 +169,7 @@ public class ArrowWriter { // swiftlint:disable:this type_body_length
                 org_apache_arrow_flatbuf_FieldNode(length: Int64(column.length),
                                                    nullCount: Int64(column.nullCount))
             offsets.append(fbb.create(struct: fieldNode))
-            if let nestedType = column.type as? ArrowNestedType {
+            if let nestedType = column.type as? ArrowTypeStruct {
                 let structArray = column.array as? StructArray
                 writeFieldNodes(nestedType.fields, columns: structArray!.arrowFields!, offsets: &offsets, fbb: &fbb)
             }
@@ -189,7 +189,7 @@ public class ArrowWriter { // swiftlint:disable:this type_body_length
                 let buffer = org_apache_arrow_flatbuf_Buffer(offset: Int64(bufferOffset), length: Int64(bufferDataSize))
                 buffers.append(buffer)
                 bufferOffset += bufferDataSize
-                if let nestedType = column.type as? ArrowNestedType {
+                if let nestedType = column.type as? ArrowTypeStruct {
                     let structArray = column.array as? StructArray
                     writeBufferInfo(nestedType.fields, columns: structArray!.arrowFields!,
                                     bufferOffset: &bufferOffset, buffers: &buffers, fbb: &fbb)
@@ -246,7 +246,7 @@ public class ArrowWriter { // swiftlint:disable:this type_body_length
             for var bufferData in colBufferData {
                 addPadForAlignment(&bufferData)
                 writer.append(bufferData)
-                if let nestedType = column.type as? ArrowNestedType {
+                if let nestedType = column.type as? ArrowTypeStruct {
                     guard let structArray = column.array as? StructArray else {
                         return .failure(.invalid("Struct type array expected for nested type"))
                     }

--- a/Arrow/Sources/Arrow/ProtoUtil.swift
+++ b/Arrow/Sources/Arrow/ProtoUtil.swift
@@ -71,7 +71,14 @@ func fromProto( // swiftlint:disable:this cyclomatic_complexity function_body_le
             children.append(fromProto(field: childField))
         }
 
-        arrowType = ArrowNestedType(ArrowType.ArrowStruct, fields: children)
+        arrowType = ArrowTypeStruct(ArrowType.ArrowStruct, fields: children)
+    case .list:
+        guard field.childrenCount == 1, let childField = field.children(at: 0) else {
+            arrowType = ArrowType(ArrowType.ArrowUnknown)
+            break
+        }
+        let childArrowField = fromProto(field: childField)
+        arrowType = ArrowTypeList(childArrowField.type)
     default:
         arrowType = ArrowType(ArrowType.ArrowUnknown)
     }

--- a/Arrow/Tests/ArrowTests/ArrayTests.swift
+++ b/Arrow/Tests/ArrowTests/ArrayTests.swift
@@ -368,4 +368,86 @@ final class ArrayTests: XCTestCase { // swiftlint:disable:this type_body_length
         boolBuilder.append([true, false, true, false])
         XCTAssertEqual(try boolBuilder.finish()[2], true)
     }
+
+    func testListArrayPrimitive() throws {
+        let listBuilder = try ListArrayBuilder(ArrowType(ArrowType.ArrowInt32))
+
+        listBuilder.append([Int32(1), Int32(2), Int32(3)])
+        listBuilder.append([Int32(4), Int32(5)])
+        listBuilder.append(nil)
+        listBuilder.append([Int32(6), Int32(7), Int32(8), Int32(9)])
+
+        XCTAssertEqual(listBuilder.length, 4)
+        XCTAssertEqual(listBuilder.nullCount, 1)
+
+        let listArray = try listBuilder.finish()
+        XCTAssertEqual(listArray.length, 4)
+
+        let firstList = listArray[0]
+        XCTAssertNotNil(firstList, "First list should not be nil")
+        XCTAssertEqual(firstList!.count, 3, "First list should have 3 elements")
+        XCTAssertEqual(firstList![0] as? Int32, 1)
+        XCTAssertEqual(firstList![1] as? Int32, 2)
+        XCTAssertEqual(firstList![2] as? Int32, 3)
+
+        let secondList = listArray[1]
+        XCTAssertEqual(secondList!.count, 2)
+        XCTAssertEqual(secondList![0] as? Int32, 4)
+        XCTAssertEqual(secondList![1] as? Int32, 5)
+
+        XCTAssertNil(listArray[2])
+
+        let fourthList = listArray[3]
+        XCTAssertEqual(fourthList!.count, 4)
+        XCTAssertEqual(fourthList![0] as? Int32, 6)
+        XCTAssertEqual(fourthList![3] as? Int32, 9)
+    }
+
+    func testNestedListArray() throws {
+        let innerListType = ArrowTypeList(ArrowType(ArrowType.ArrowInt32))
+        let outerListBuilder = try ListArrayBuilder(innerListType)
+
+        let innerListBuilder = outerListBuilder.valueBuilder as! ListArrayBuilder
+
+        outerListBuilder.bufferBuilder.append([nil, nil])
+        innerListBuilder.append([Int32(1), Int32(2)])
+        innerListBuilder.append([Int32(3), Int32(4), Int32(5)])
+
+        outerListBuilder.bufferBuilder.append([nil])
+        innerListBuilder.append([Int32(6)])
+
+        outerListBuilder.bufferBuilder.append(nil)
+
+        outerListBuilder.bufferBuilder.append([])
+
+        let nestedArray = try outerListBuilder.finish()
+        XCTAssertEqual(nestedArray.length, 4)
+        XCTAssertEqual(nestedArray.nullCount, 1)
+
+        let firstOuterList = nestedArray[0]!
+        XCTAssertEqual(firstOuterList.count, 2)
+
+        let firstInnerList = firstOuterList[0] as! [Any?]
+        XCTAssertEqual(firstInnerList.count, 2)
+        XCTAssertEqual(firstInnerList[0] as? Int32, 1)
+        XCTAssertEqual(firstInnerList[1] as? Int32, 2)
+
+        let secondInnerList = firstOuterList[1] as! [Any?]
+        XCTAssertEqual(secondInnerList.count, 3)
+        XCTAssertEqual(secondInnerList[0] as? Int32, 3)
+        XCTAssertEqual(secondInnerList[1] as? Int32, 4)
+        XCTAssertEqual(secondInnerList[2] as? Int32, 5)
+
+        let secondOuterList = nestedArray[1]!
+        XCTAssertEqual(secondOuterList.count, 1)
+
+        let thirdInnerList = secondOuterList[0] as! [Any?]
+        XCTAssertEqual(thirdInnerList.count, 1)
+        XCTAssertEqual(thirdInnerList[0] as? Int32, 6)
+
+        XCTAssertNil(nestedArray[2])
+
+        let emptyList = nestedArray[3]!
+        XCTAssertEqual(emptyList.count, 0)
+    }
 }

--- a/Arrow/Tests/ArrowTests/IPCTests.swift
+++ b/Arrow/Tests/ArrowTests/IPCTests.swift
@@ -121,14 +121,14 @@ func makeSchema() -> ArrowSchema {
 func makeStructSchema() -> ArrowSchema {
     let testObj = StructTest()
     var fields = [ArrowField]()
-    let buildStructType = {() -> ArrowNestedType in
+    let buildStructType = {() -> ArrowTypeStruct in
         let mirror = Mirror(reflecting: testObj)
         for (property, value) in mirror.children {
             let arrowType = ArrowType(ArrowType.infoForType(type(of: value)))
             fields.append(ArrowField(property!, type: arrowType, isNullable: true))
         }
 
-        return ArrowNestedType(ArrowType.ArrowStruct, fields: fields)
+        return ArrowTypeStruct(ArrowType.ArrowStruct, fields: fields)
     }
 
     return ArrowSchema.Builder()
@@ -515,8 +515,8 @@ final class IPCFileReaderTests: XCTestCase { // swiftlint:disable:this type_body
                     XCTAssertEqual(recordBatch.schema.fields.count, 1)
                     XCTAssertEqual(recordBatch.schema.fields[0].name, "struct1")
                     XCTAssertEqual(recordBatch.schema.fields[0].type.id, .strct)
-                    XCTAssertTrue(recordBatch.schema.fields[0].type is ArrowNestedType)
-                    let nestedType = (recordBatch.schema.fields[0].type as? ArrowNestedType)!
+                    XCTAssertTrue(recordBatch.schema.fields[0].type is ArrowTypeStruct)
+                    let nestedType = (recordBatch.schema.fields[0].type as? ArrowTypeStruct)!
                     XCTAssertEqual(nestedType.fields.count, 14)
                     let columns = recordBatch.columns
                     XCTAssertEqual(columns[0].nullCount, 1)

--- a/Arrow/Tests/ArrowTests/TableTests.swift
+++ b/Arrow/Tests/ArrowTests/TableTests.swift
@@ -53,14 +53,14 @@ final class TableTests: XCTestCase {
 
         let testObj = StructTest()
         var fields = [ArrowField]()
-        let buildStructType = {() -> ArrowNestedType in
+        let buildStructType = {() -> ArrowTypeStruct in
             let mirror = Mirror(reflecting: testObj)
             for (property, value) in mirror.children {
                 let arrowType = ArrowType(ArrowType.infoForType(type(of: value)))
                 fields.append(ArrowField(property!, type: arrowType, isNullable: true))
             }
 
-            return ArrowNestedType(ArrowType.ArrowStruct, fields: fields)
+            return ArrowTypeStruct(ArrowType.ArrowStruct, fields: fields)
         }
 
         let structType = buildStructType()


### PR DESCRIPTION
### Rationale within the changes

This PR refactors and extends support for nested types in the Arrow integration. The current implementation of `ArrowNestedType` is tailored primarily for data structs, as seen in `StructBufferBuilder`. However, it lacks broader support and certain expected functionalities, such as `loadStructArrayBuilder`.

To address this, the following improvements have been made:

- Renamed `ArrowNestedType` to `ArrowTypeStruct` to align with naming conventions used elsewhere in the codebase.
- Introduced initial support for `ArrowTypeList`, including nested lists.

For simplicity, instead of introducing a dedicated subtype for lists, this PR uses an interface of `[Any?]?`. If this approach proves insufficient, there are more explicit alternatives that can be explored.

**NOTE:** Work on `ArrowCExporter` and `ArrowCImporter` has been intentionally deferred. These components require a deeper understanding of memory ownership and child parsing, and I believe it's better to be addressed in a future PR, unless it's strict necessary.

### What's Changed

1. Renamed `ArrowNestedType -> ArrowTypeStruct`.
2. Added support for `ArrowTypeList`, including nested lists.
3. Implemented `ListArray` with basic `.asString` formatting.
4. Added `ListArrayBuilder`.
5. Extended `ArrowArrayBuilder` to support the `.list` type.
6. Implemented `loadStructArrayBuilder` and `loadListArrayBuilder`.
7. Introduced `ListBufferBuilder`.
8. Added `ArrowReader.loadListData`.
9. Added `makeListHolder`.

### Are these changes tested?

Tests are included in `ArrayTests.swift`. It's also working on internal applications, including integration with `ArrowFlight`.