### PR TITLE
chore: Add CI jobs for Swift 6.0 and 6.1

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -86,6 +86,8 @@ jobs:
         run: |
           docker compose build ubuntu
       - name: Run
+        # We remove this when we support Swift 6.0 or later.
+        continue-on-error: ${{ matrix.swift-version != '5.10' }}
         run: |
           docker compose run --rm ubuntu
       - name: Fix permission for .docker/

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -56,21 +56,29 @@ jobs:
           pre-commit run --show-diff-on-failure --color=always --all-files
 
   docker:
-    name: Ubuntu Swift 5.10
+    name: Ubuntu Swift ${{ matrix.swift-version }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        swift-version:
+          - "5.10"
+          - "6.0"
+          - "6.1"
     permissions:
       packages: write
     env:
       DOCKER_VOLUME_PREFIX: .docker/
+      SWIFT: ${{ matrix.swift-version }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Cache
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: .docker
-          key: docker-${{ hashFiles('**/Package.resolved', '**/go.sum') }}
-          restore-keys: docker-
+          key: docker-${{ matrix.swift-version }}-${{ hashFiles('**/Package.resolved', '**/go.sum') }}
+          restore-keys: docker-${{ matrix.swift-version }}-
       - name: Pull
         run: |
           docker compose pull --ignore-pull-failures ubuntu

--- a/compose.yaml
+++ b/compose.yaml
@@ -37,12 +37,12 @@ services:
     # Usage:
     #   docker compose build ubuntu
     #   docker compose run ubuntu
-    image: ${REPO}:${ARCH}-ubuntu-${UBUNTU_CODE_NAME}
+    image: ${REPO}:${ARCH}-${SWIFT}-ubuntu-${UBUNTU_CODE_NAME}
     build:
       context: .
       dockerfile: ci/docker/ubuntu.dockerfile
       cache_from:
-        - ${REPO}:${ARCH}-ubuntu-${UBUNTU_CODE_NAME}
+        - ${REPO}:${ARCH}-${SWIFT}-ubuntu-${UBUNTU_CODE_NAME}
       args:
         SWIFT: ${SWIFT}
         UBUNTU_CODE_NAME: ${UBUNTU_CODE_NAME}


### PR DESCRIPTION
## What's Changed

Add CI jobs for Swift 6.0 and 6.1 but these results are ignored. Because they aren't supported yet.

Closes #45.
