### PR TITLE
chore: Focus on actual errors by removing `-warnings-as-errors`

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -86,8 +86,6 @@ jobs:
         run: |
           docker compose build ubuntu
       - name: Run
-        # We remove this when we support Swift 6.0 or later.
-        continue-on-error: ${{ matrix.swift-version != '5.10' }}
         run: |
           docker compose run --rm ubuntu
       - name: Fix permission for .docker/

--- a/ci/scripts/build.sh
+++ b/ci/scripts/build.sh
@@ -57,15 +57,6 @@ cp *.arrow ../../Arrow
 popd
 github_actions_group_end
 
-github_actions_group_begin "Use -warnings-as-errors"
-for package in . Arrow ArrowFlight; do
-  pushd "${build_dir}/source/${package}"
-  sed 's/\/\/ build://g' Package.swift > Package.swift.build
-  mv Package.swift.build Package.swift
-  popd
-done
-github_actions_group_end
-
 github_actions_group_begin "Build"
 pushd "${build_dir}/source"
 swift build


### PR DESCRIPTION
## What's Changed

This PR aims to focus on real errors by removing `-warnings-as-errors` flag.

To make it sure, this PR removes the following from CI test pipelines.

https://github.com/apache/arrow-swift/blob/b6ca546b2e56afc23bd75bbc69e6123071438165/.github/workflows/test.yaml#L89-L90

We can enable `-warnings-as-errors` later .