### PR TITLE
GH-57: Upgrade `grpc-swift` to `1.26.1` and `swift-protobuf` to `1.30.0`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -32,8 +32,8 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/google/flatbuffers.git", branch: "v25.2.10"),
-        .package(url: "https://github.com/grpc/grpc-swift.git", from: "1.25.0"),
-        .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.29.0"),
+        .package(url: "https://github.com/grpc/grpc-swift.git", from: "1.26.1"),
+        .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.30.0"),
         .package(
             url: "https://github.com/apple/swift-atomics.git",
             .upToNextMajor(from: "1.2.0") // or `.upToNextMinor


### PR DESCRIPTION
## What's Changed

This PR aims to update the dependencies up-to-date.

- `grpc-swift` from `1.25.0` to `1.26.1`.
- `swift-protobuf` from `1.29.0` to `1.30.0`.

Closes #57 .
