### PR TITLE
chore: Use package(from:) for Dependabot friendly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,42 +20,42 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     commit-message:
       prefix: "chore: "
     open-pull-requests-limit: 10
   - package-ecosystem: "swift"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     commit-message:
       prefix: "chore: "
     open-pull-requests-limit: 10
   - package-ecosystem: "swift"
     directory: "/Arrow/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     commit-message:
       prefix: "chore: "
     open-pull-requests-limit: 10
   - package-ecosystem: "swift"
     directory: "/ArrowFlight/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     commit-message:
       prefix: "chore: "
     open-pull-requests-limit: 10
   - package-ecosystem: "gomod"
     directory: "/CDataWGo/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     commit-message:
       prefix: "chore: "
     open-pull-requests-limit: 10
   - package-ecosystem: "gomod"
     directory: "/data-generator/swift-datagen/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     commit-message:
       prefix: "chore: "
     open-pull-requests-limit: 10

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -78,7 +78,11 @@ jobs:
         with:
           path: .docker
           key: docker-${{ matrix.swift-version }}-${{ hashFiles('**/Package.resolved', '**/go.sum') }}
-          restore-keys: docker-${{ matrix.swift-version }}-
+          # Don't reuse existing cache because "git fetch" is failed
+          # in Docker without "git config --global --add
+          # safe.directory".
+          #
+          # restore-keys: docker-${{ matrix.swift-version }}-
       - name: Pull
         run: |
           docker compose pull --ignore-pull-failures ubuntu

--- a/Arrow/Package.resolved
+++ b/Arrow/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "e67f1e8991668b9995542ad611ac8d108d6689394edfa3a2597eeb3995615ec3",
+  "originHash" : "bf353d71e72c7f9a8c9662e9debaf3c9a0e4127ad01dca316cc273758f5c8391",
   "pins" : [
     {
       "identity" : "flatbuffers",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/flatbuffers.git",
       "state" : {
-        "branch" : "v25.2.10",
-        "revision" : "1c514626e83c20fffa8557e75641848e1e15cd5e"
+        "revision" : "1c514626e83c20fffa8557e75641848e1e15cd5e",
+        "version" : "25.2.10"
       }
     },
     {

--- a/Arrow/Package.swift
+++ b/Arrow/Package.swift
@@ -31,11 +31,8 @@ let package = Package(
             targets: ["Arrow"])
     ],
     dependencies: [
-        .package(url: "https://github.com/google/flatbuffers.git", branch: "v25.2.10"),
-        .package(
-            url: "https://github.com/apple/swift-atomics.git",
-            .upToNextMajor(from: "1.2.0") // or `.upToNextMinor
-        )
+        .package(url: "https://github.com/google/flatbuffers.git", from: "25.2.10"),
+        .package(url: "https://github.com/apple/swift-atomics.git", from: "1.3.0")
     ],
     targets: [
         .target(

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "43598045d6f0efb846016fdaf06ce4c4af178788fbc0debcfe7d4e58d14edfd2",
+  "originHash" : "49d6d0d022dee6489604e505c65f001dcb52b05369213b70ef57fa1e86248808",
   "pins" : [
     {
       "identity" : "flatbuffers",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/flatbuffers.git",
       "state" : {
-        "branch" : "v25.2.10",
-        "revision" : "1c514626e83c20fffa8557e75641848e1e15cd5e"
+        "revision" : "1c514626e83c20fffa8557e75641848e1e15cd5e",
+        "version" : "25.2.10"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -31,13 +31,10 @@ let package = Package(
             targets: ["Arrow"])
     ],
     dependencies: [
-        .package(url: "https://github.com/google/flatbuffers.git", branch: "v25.2.10"),
+        .package(url: "https://github.com/google/flatbuffers.git", from: "25.2.10"),
         .package(url: "https://github.com/grpc/grpc-swift.git", from: "1.25.0"),
         .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.29.0"),
-        .package(
-            url: "https://github.com/apple/swift-atomics.git",
-            .upToNextMajor(from: "1.2.0") // or `.upToNextMinor
-        )
+        .package(url: "https://github.com/apple/swift-atomics.git", from: "1.3.0")
     ],
     targets: [
         .target(


### PR DESCRIPTION
## What's Changed

Use `package(from:)` because Dependabot doesn't like `upToNextMajor()`.

This also changes `package()` for FlatBuffers. We can use `from:` not `branch:` for FlatBuffers too.

This also changes Dependabot interval to trigger the next Dependabot runs immediately.

Closes #59.
