### PR TITLE
chore: Remove "Swift" suffix from package name

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@
 import PackageDescription
 
 let package = Package(
-    name: "ArrowSwift",
+    name: "Arrow",
     platforms: [
         .macOS(.v10_15)
     ],


### PR DESCRIPTION
## What's Changed

"Swift" is redundant.

Closes #47.
