### PR TITLE
chore: Add missing `discussions: write` permission to release job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,6 +25,7 @@ on:
 
 permissions:
   contents: write
+  discussions: write
 
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What's Changed

We need `discussions: write` permission to create a new discussion by `gh release create --discussion-category`.

Closes #80.
