### PR TITLE
fix: use exact version for FlatBuffers dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -31,7 +31,7 @@ let package = Package(
             targets: ["Arrow"])
     ],
     dependencies: [
-        .package(url: "https://github.com/google/flatbuffers.git", from: "25.2.10"),
+        .package(url: "https://github.com/google/flatbuffers.git", exact: "25.2.10"),
         .package(url: "https://github.com/grpc/grpc-swift.git", from: "1.25.0"),
         .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.29.0"),
         .package(url: "https://github.com/apple/swift-atomics.git", from: "1.3.0")


### PR DESCRIPTION
### What changes are included in this PR?

This PR updates the `google/flatbuffers` dependency in `Package.swift` to use the `exact` version requirement (`exact: "25.2.10"`) instead of the previous `from:` requirement.

### Why are these changes necessary?

The `from:` parameter allows the Swift Package Manager to automatically resolve and fetch newer minor versions. However, FlatBuffers has a known history of introducing breaking API changes between minor updates. Allowing floating versions can silently break the `*_generated.swift` files and disrupt the build process for anyone depending on this package. 

Pinning the dependency to an exact version acts as a strict contract, ensuring build stability, predictable code generation, and preventing upstream surprises.

### Related Issues

Closes #114