### PR TITLE
fix(package): expose ArrowFlight as public product

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,10 @@ let package = Package(
     products: [
         .library(
             name: "Arrow",
-            targets: ["Arrow"])
+            targets: ["Arrow"]),
+        .library(
+            name: "ArrowFlight",
+            targets: ["ArrowFlight"])
     ],
     dependencies: [
         .package(url: "https://github.com/google/flatbuffers.git", from: "25.2.10"),


### PR DESCRIPTION
## Summary

Expose ArrowFlight as public library product:

- **File**: `Package.swift`
- **Change**: Added `.library(name: "ArrowFlight", targets: ["ArrowFlight"])` to products array
- **Impact**: 
  - Downstream packages can now `import ArrowFlight` when depending on arrow-swift
  - Resolves issue where ArrowFlight target existed but was not importable

## Testing

- `swift build` succeeds
- Existing unit tests pass
- Verified ArrowFlight module is now resolvable in dependent package
- Validated buffer alignment with IPC round-trip test

## Related Issues

- Closes #115

## Breaking Changes

None.