### PR TITLE
chore: Use integer arithmetic instead of `ceil` in `Arrow(Reader|CImporter)`

### DIFF
--- a/Sources/Arrow/ArrowCImporter.swift
+++ b/Sources/Arrow/ArrowCImporter.swift
@@ -136,7 +136,7 @@ public class ArrowCImporter {
                         .invalid("Variable buffer count expected 3 but found \(cArray.n_buffers)"))
                 }
 
-                appendToBuffer(cArray.buffers[0], arrowBuffers: &arrowBuffers, length: UInt(ceil(Double(length) / 8)))
+                appendToBuffer(cArray.buffers[0], arrowBuffers: &arrowBuffers, length: (length + 7) / 8)
                 appendToBuffer(cArray.buffers[1], arrowBuffers: &arrowBuffers, length: length)
                 let lastOffsetLength = cArray.buffers[1]!
                     .advanced(by: Int(length) * MemoryLayout<Int32>.stride)
@@ -148,7 +148,7 @@ public class ArrowCImporter {
                     return .failure(.invalid("Expected buffer count 2 but found \(cArray.n_buffers)"))
                 }
 
-                appendToBuffer(cArray.buffers[0], arrowBuffers: &arrowBuffers, length: UInt(ceil(Double(length) / 8)))
+                appendToBuffer(cArray.buffers[0], arrowBuffers: &arrowBuffers, length: (length + 7) / 8)
                 appendToBuffer(cArray.buffers[1], arrowBuffers: &arrowBuffers, length: length)
             }
         }

--- a/Sources/Arrow/ArrowReader.swift
+++ b/Sources/Arrow/ArrowReader.swift
@@ -97,7 +97,7 @@ public class ArrowReader { // swiftlint:disable:this type_body_length
             return .failure(.invalid("Null buffer not found"))
         }
 
-        let nullLength = UInt(ceil(Double(node.length) / 8))
+        let nullLength = (UInt(node.length) + 7) / 8
         let arrowNullBuffer = makeBuffer(nullBuffer, fileData: loadInfo.fileData,
                                          length: nullLength, messageOffset: loadInfo.messageOffset)
         var children = [ArrowData]()
@@ -129,7 +129,7 @@ public class ArrowReader { // swiftlint:disable:this type_body_length
             return .failure(.invalid("Offset buffer not found"))
         }
 
-        let nullLength = UInt(ceil(Double(node.length) / 8))
+        let nullLength = (UInt(node.length) + 7) / 8
         let arrowNullBuffer = makeBuffer(nullBuffer, fileData: loadInfo.fileData, length: nullLength, messageOffset: loadInfo.messageOffset)
         let arrowOffsetBuffer = makeBuffer(offsetBuffer, fileData: loadInfo.fileData, length: UInt(node.length + 1), messageOffset: loadInfo.messageOffset)
 
@@ -161,7 +161,7 @@ public class ArrowReader { // swiftlint:disable:this type_body_length
             return .failure(.invalid("Value buffer not found"))
         }
 
-        let nullLength = UInt(ceil(Double(node.length) / 8))
+        let nullLength = (UInt(node.length) + 7) / 8
         let arrowNullBuffer = makeBuffer(nullBuffer, fileData: loadInfo.fileData,
                                          length: nullLength, messageOffset: loadInfo.messageOffset)
         let arrowValueBuffer = makeBuffer(valueBuffer, fileData: loadInfo.fileData,
@@ -191,7 +191,7 @@ public class ArrowReader { // swiftlint:disable:this type_body_length
             return .failure(.invalid("Value buffer not found"))
         }
 
-        let nullLength = UInt(ceil(Double(node.length) / 8))
+        let nullLength = (UInt(node.length) + 7) / 8
         let arrowNullBuffer = makeBuffer(nullBuffer, fileData: loadInfo.fileData,
                                          length: nullLength, messageOffset: loadInfo.messageOffset)
         let arrowOffsetBuffer = makeBuffer(offsetBuffer, fileData: loadInfo.fileData,


### PR DESCRIPTION
## What's Changed

Use integer arithmetic `(n + 7) / 8` instead of `ceil(Double(n) / 8)` for null buffer length calculation in `ArrowReader` and `ArrowCImporter`.

This avoids unnecessary floating-point conversion.

Note that this is a part of subtasks of [SPARK-56063 Improve Linux Support](https://issues.apache.org/jira/browse/SPARK-56063)
- https://github.com/apache/spark-connect-swift/pull/314

Generated-by: Claude Code (Claude Opus 4.6)