### PR TITLE
chore: Add Swift 6.2 to `test.yaml`

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -66,6 +66,7 @@ jobs:
           - "5.10"
           - "6.0"
           - "6.1"
+          - "6.2"
     permissions:
       packages: write
     env:


### PR DESCRIPTION
## What's Changed

Add Swift 6.2 to the CI test matrix.

- https://www.swift.org/blog/swift-6.2-released/

Generated-by: Claude Code (Claude Opus 4.6)