### PR TITLE
fix: Handle files shorter than the Arrow file marker

### DIFF
--- a/Sources/Arrow/ArrowReaderHelper.swift
+++ b/Sources/Arrow/ArrowReaderHelper.swift
@@ -324,9 +324,10 @@ func validateBufferIndex(_ recordBatch: org_apache_arrow_flatbuf_RecordBatch, in
 }
 
 func validateFileData(_ data: Data) -> Bool {
-    let markerLength = FILEMARKER.utf8.count
-    let startString = String(decoding: data[..<markerLength], as: UTF8.self)
-    let endString = String(decoding: data[(data.count - markerLength)...], as: UTF8.self)
+    let markerLength: Int = FILEMARKER.utf8.count
+    guard data.count >= markerLength * 2 else { return false }
+    let startString: String = String(decoding: data.prefix(markerLength), as: UTF8.self)
+    let endString: String = String(decoding: data.suffix(markerLength), as: UTF8.self)
     return startString == FILEMARKER && endString == FILEMARKER
 }
 

--- a/Tests/ArrowTests/IPCTests.swift
+++ b/Tests/ArrowTests/IPCTests.swift
@@ -671,5 +671,48 @@ final class IPCFileReaderTests: XCTestCase { // swiftlint:disable:this type_body
             throw error
         }
     }
+
+    func testFromFileWithInvalidData() throws {
+        let reader = ArrowReader()
+
+        // Test empty file
+        let emptyUrl = FileManager.default.temporaryDirectory
+            .appendingPathComponent("empty_\(UUID().uuidString).bin")
+        try Data().write(to: emptyUrl)
+        defer { try? FileManager.default.removeItem(at: emptyUrl) }
+
+        switch reader.fromFile(emptyUrl) {
+        case .success:
+            XCTFail("Expected failure for empty file")
+        case .failure:
+            break // Correct: should fail gracefully
+        }
+
+        // Test file with single byte
+        let singleByteUrl = FileManager.default.temporaryDirectory
+            .appendingPathComponent("single_\(UUID().uuidString).bin")
+        try Data([0x41]).write(to: singleByteUrl)
+        defer { try? FileManager.default.removeItem(at: singleByteUrl) }
+
+        switch reader.fromFile(singleByteUrl) {
+        case .success:
+            XCTFail("Expected failure for single byte file")
+        case .failure:
+            break
+        }
+
+        // Test file with partial marker
+        let partialUrl = FileManager.default.temporaryDirectory
+            .appendingPathComponent("partial_\(UUID().uuidString).bin")
+        try Data("ARROW".utf8).write(to: partialUrl)  // "ARROW" = 5 bytes, marker is 6
+        defer { try? FileManager.default.removeItem(at: partialUrl) }
+
+        switch reader.fromFile(partialUrl) {
+        case .success:
+            XCTFail("Expected failure for partial marker file")
+        case .failure:
+            break
+        }
+    }
 }
 // swiftlint:disable:this file_length


### PR DESCRIPTION
## What's Changed

Fixed a crash in `ArrowReader.fromFile()` when processing files smaller than the Arrow file marker size (6 bytes). The function now gracefully returns a `.failure` result instead of crashing with a fatal range error.

### Root Cause

The `validateFileData()` function in `ArrowReaderHelper.swift` attempted to read the first and last 6 bytes of the input data without checking if the data was large enough. When `data.count < 6`, subscript operations like `data[..<6]` would fail with a range error, causing a crash.

### Changes Made

1. Added a bounds check: `guard data.count >= markerLength * 2 else { return false }`
2. Replaced direct subscripting with `prefix()` and `suffix()` for safer slice operations
3. Added unit tests to verify the fix handles edge cases:
   - Empty files
   - Files smaller than marker size
   - Files with partial markers

### Testing

- New test `testFromFileWithInvalidData()` added to `IPCFileReaderTests`
- Test verifies that invalid files return `.failure` instead of crashing
- All existing tests continue to pass

### Impact

This fix improves robustness for applications using `ArrowReader.fromFile()` with user-supplied or untrusted files, preventing denial of service from truncated or malformed input.

Closes #176
