### PR TITLE
fix: Honor useUnalignedBuffers in ArrowReader.readStreaming

### DIFF
--- a/Sources/Arrow/ArrowReader.swift
+++ b/Sources/Arrow/ArrowReader.swift
@@ -277,7 +277,7 @@ public class ArrowReader { // swiftlint:disable:this type_body_length
             streamData = input[offset...]
             var dataBuffer = ByteBuffer(
                 data: streamData,
-                allowReadingUnalignedBuffers: true
+                allowReadingUnalignedBuffers: useUnalignedBuffers
             )
             let message: org_apache_arrow_flatbuf_Message = getRoot(byteBuffer: &dataBuffer)
             switch message.headerType {


### PR DESCRIPTION
## What's Changed

`readStreaming` declared a `useUnalignedBuffers` parameter and ignored it,
hardcoding `allowReadingUnalignedBuffers: true` when constructing the
`ByteBuffer`. This forwards the caller's value, matching `readFile` and
`fromMessage`, which already do so.

## Testing

The full test suite passes with this change.

No new test is included: the flag selects between aligned and unaligned
loads inside FlatBuffers and does not affect the result of any read on this
path, because `ByteBuffer(data:)` copies the input into aligned storage. A
test exercising the parameter would pass both with and without this change,
so it would not guard against a regression.

The streaming reader is already covered by `IPCStreamReaderTests` and the
streaming cases in `IPCFileReaderTests`.

Closes #178.