### PR TITLE
fix(ArrowBuilder): correct null bit checking logic and add tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,7 @@
 DerivedData/
 Packages/
 xcuserdata/
-
+.vscode/
 # Docker
 /.docker/
 

--- a/Sources/Arrow/ArrowBufferBuilder.swift
+++ b/Sources/Arrow/ArrowBufferBuilder.swift
@@ -42,7 +42,7 @@ public class BaseBufferBuilder {
     }
 
     public func isNull(_ index: UInt) -> Bool {
-        return self.nulls.length == 0 || BitUtility.isSet(index + self.offset, buffer: self.nulls)
+        return !BitUtility.isSet(index + self.offset, buffer: self.nulls)
     }
 
     func resizeLength(_ data: ArrowBuffer, len: UInt = 0) -> UInt {
@@ -427,10 +427,6 @@ public class ListBufferBuilder: BaseBufferBuilder, ArrowBufferBuilder {
             BitUtility.clearBit(index + self.offset, buffer: self.nulls)
             self.offsets.rawPointer.advanced(by: offsetIndex + MemoryLayout<Int32>.stride).storeBytes(of: currentOffset, as: Int32.self)
         }
-    }
-
-    public override func isNull(_ index: UInt) -> Bool {
-        return !BitUtility.isSet(index + self.offset, buffer: self.nulls)
     }
 
     public func resize(_ length: UInt) {

--- a/Tests/ArrowTests/ArrayBuilderTest.swift
+++ b/Tests/ArrowTests/ArrayBuilderTest.swift
@@ -82,4 +82,98 @@ final class ArrayBuilderTests: XCTestCase {
         XCTAssertThrowsError(try ArrowArrayBuilders.loadBuilder(Int?.self))
         XCTAssertThrowsError(try ArrowArrayBuilders.loadBuilder(UInt?.self))
     }
+
+    func testFixedBufferBuilderIsNull() throws {
+        let builder: FixedBufferBuilder<Int32> = try FixedBufferBuilder()
+        builder.append(42)
+        builder.append(nil)
+        builder.append(7)
+
+        XCTAssertFalse(builder.isNull(0), "Value 42 should not be null")
+        XCTAssertTrue(builder.isNull(1), "Nil value should be null")
+        XCTAssertFalse(builder.isNull(2), "Value 7 should not be null")
+        XCTAssertEqual(builder.nullCount, 1)
+    }
+
+    func testBoolBufferBuilderIsNull() throws {
+        let builder = try BoolBufferBuilder()
+        builder.append(true)
+        builder.append(nil)
+        builder.append(false)
+
+        XCTAssertFalse(builder.isNull(0), "Value true should not be null")
+        XCTAssertTrue(builder.isNull(1), "Nil value should be null")
+        XCTAssertFalse(builder.isNull(2), "Value false should not be null")
+        XCTAssertEqual(builder.nullCount, 1)
+    }
+
+    func testVariableBufferBuilderIsNull() throws {
+        let builder = try VariableBufferBuilder<String>()
+        builder.append("hello")
+        builder.append(nil)
+        builder.append("world")
+
+        XCTAssertFalse(builder.isNull(0), "String 'hello' should not be null")
+        XCTAssertTrue(builder.isNull(1), "Nil value should be null")
+        XCTAssertFalse(builder.isNull(2), "String 'world' should not be null")
+        XCTAssertEqual(builder.nullCount, 1)
+    }
+
+    func testFixedBufferBuilderIsNullMultiple() throws {
+        let builder: FixedBufferBuilder<Double> = try FixedBufferBuilder()
+        builder.append(1.5)
+        builder.append(nil)
+        builder.append(2.5)
+        builder.append(nil)
+        builder.append(3.5)
+
+        XCTAssertFalse(builder.isNull(0))
+        XCTAssertTrue(builder.isNull(1))
+        XCTAssertFalse(builder.isNull(2))
+        XCTAssertTrue(builder.isNull(3))
+        XCTAssertFalse(builder.isNull(4))
+        XCTAssertEqual(builder.nullCount, 2)
+    }
+
+    func testBoolBufferBuilderIsNullMultiple() throws {
+        let builder = try BoolBufferBuilder()
+        builder.append(true)
+        builder.append(true)
+        builder.append(nil)
+        builder.append(false)
+        builder.append(nil)
+        builder.append(false)
+
+        XCTAssertFalse(builder.isNull(0))
+        XCTAssertFalse(builder.isNull(1))
+        XCTAssertTrue(builder.isNull(2))
+        XCTAssertFalse(builder.isNull(3))
+        XCTAssertTrue(builder.isNull(4))
+        XCTAssertFalse(builder.isNull(5))
+        XCTAssertEqual(builder.nullCount, 2)
+    }
+
+    func testFixedBufferBuilderIsNullAllNulls() throws {
+        let builder: FixedBufferBuilder<Int8> = try FixedBufferBuilder()
+        builder.append(nil)
+        builder.append(nil)
+        builder.append(nil)
+
+        XCTAssertTrue(builder.isNull(0))
+        XCTAssertTrue(builder.isNull(1))
+        XCTAssertTrue(builder.isNull(2))
+        XCTAssertEqual(builder.nullCount, 3)
+    }
+
+    func testFixedBufferBuilderIsNullNoNulls() throws {
+        let builder: FixedBufferBuilder<UInt64> = try FixedBufferBuilder()
+        builder.append(100)
+        builder.append(200)
+        builder.append(300)
+
+        XCTAssertFalse(builder.isNull(0))
+        XCTAssertFalse(builder.isNull(1))
+        XCTAssertFalse(builder.isNull(2))
+        XCTAssertEqual(builder.nullCount, 0)
+    }
 }


### PR DESCRIPTION
## What's Changed

`BaseBufferBuilder.isNull(_:)` was returning the inverse of the null state. When `append()` writes a non-null value, it calls `setBit`; when writing null, it calls `clearBit`. So a set bit means valid. The function was returning `isSet()`, which means it reported valid values as null and null values as valid.

This fix removes the inverted logic and aligns with `ArrowData.isNull()`, which correctly uses `!isSet()`.

Removed redundant `ListBufferBuilder.isNull()` override that is now identical to the base implementation.

## Testing

Added comprehensive unit tests covering:
- Single null and non-null values
- Multiple mixed nulls and values
- All-null cases
- All-non-null cases

All 7 new tests pass. Existing test suite continues to pass.

## Impact

No code inside the library calls the builders' `isNull` — all internal readers go through `ArrowData.isNull` — so this affects external users of the public builder API only.

Closes #180 