### PR TITLE
feat: Add Arrow JSON integration testing executable. Fix ArrowReader bug.

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -30,3 +30,5 @@ excluded:
 identifier_name:
   min_length: 2 # only warning
 allow_zero_lintable_files: false
+cyclomatic_complexity:
+  ignores_case_statements: true

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "49d6d0d022dee6489604e505c65f001dcb52b05369213b70ef57fa1e86248808",
+  "originHash" : "c23c1f5c89107ed8f70ed091945eabcbd1e5d4ba245d683e17b185cf7cc45da6",
   "pins" : [
     {
       "identity" : "flatbuffers",
@@ -26,6 +26,15 @@
       "state" : {
         "revision" : "87e50f483c54e6efd60e885f7f5aa946cee68023",
         "version" : "1.2.1"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "6a52f3251125d74daf04fcbd5e6f08a75d074382",
+        "version" : "1.8.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -31,13 +31,15 @@ let package = Package(
             targets: ["Arrow"]),
         .library(
             name: "ArrowFlight",
-            targets: ["ArrowFlight"])
+            targets: ["ArrowFlight"]),
+        .executable(name: "arrow-json-integration-test", targets: ["ArrowJSONIntegrationTest"])
     ],
     dependencies: [
         .package(url: "https://github.com/google/flatbuffers.git", exact: "25.2.10"),
         .package(url: "https://github.com/grpc/grpc-swift.git", from: "1.25.0"),
         .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.29.0"),
-        .package(url: "https://github.com/apple/swift-atomics.git", from: "1.3.0")
+        .package(url: "https://github.com/apple/swift-atomics.git", from: "1.3.0"),
+        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.7.0"),
     ],
     targets: [
         .target(
@@ -80,7 +82,13 @@ let package = Package(
             swiftSettings: [
                 // build: .unsafeFlags(["-warnings-as-errors"])
             ]
+        ),
+        .executableTarget(
+            name: "ArrowJSONIntegrationTest",
+            dependencies: [
+                "Arrow",
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
+            ]
         )
-
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -39,7 +39,7 @@ let package = Package(
         .package(url: "https://github.com/grpc/grpc-swift.git", from: "1.25.0"),
         .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.29.0"),
         .package(url: "https://github.com/apple/swift-atomics.git", from: "1.3.0"),
-        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.7.0"),
+        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.7.0")
     ],
     targets: [
         .target(
@@ -87,7 +87,7 @@ let package = Package(
             name: "ArrowJSONIntegrationTest",
             dependencies: [
                 "Arrow",
-                .product(name: "ArgumentParser", package: "swift-argument-parser"),
+                .product(name: "ArgumentParser", package: "swift-argument-parser")
             ]
         )
     ]

--- a/Sources/Arrow/ArrowReader.swift
+++ b/Sources/Arrow/ArrowReader.swift
@@ -161,7 +161,8 @@ public class ArrowReader { // swiftlint:disable:this type_body_length
             return .failure(.invalid("Value buffer not found"))
         }
 
-        let nullLength = (UInt(node.length) + 7) / 8
+        // Null buffer may be zero-length indicating all array elements are valid.
+        let nullLength: UInt = nullBuffer.length > 0 ? (UInt(node.length) + 7) / 8 : 0
         let arrowNullBuffer = makeBuffer(nullBuffer, fileData: loadInfo.fileData,
                                          length: nullLength, messageOffset: loadInfo.messageOffset)
         let arrowValueBuffer = makeBuffer(valueBuffer, fileData: loadInfo.fileData,

--- a/Sources/Arrow/ArrowReader.swift
+++ b/Sources/Arrow/ArrowReader.swift
@@ -162,7 +162,7 @@ public class ArrowReader { // swiftlint:disable:this type_body_length
         }
 
         // Null buffer may be zero-length indicating all array elements are valid.
-        let nullLength: UInt = nullBuffer.length > 0 ? (UInt(node.length) + 7) / 8 : 0
+        let nullLength = UInt(nullBuffer.length)
         let arrowNullBuffer = makeBuffer(nullBuffer, fileData: loadInfo.fileData,
                                          length: nullLength, messageOffset: loadInfo.messageOffset)
         let arrowValueBuffer = makeBuffer(valueBuffer, fileData: loadInfo.fileData,

--- a/Sources/Arrow/ArrowSchema.swift
+++ b/Sources/Arrow/ArrowSchema.swift
@@ -21,7 +21,7 @@ public class ArrowField {
     public let name: String
     public let isNullable: Bool
 
-    init(_ name: String, type: ArrowType, isNullable: Bool) {
+    public init(_ name: String, type: ArrowType, isNullable: Bool) {
         self.name = name
         self.type = type
         self.isNullable = isNullable

--- a/Sources/Arrow/ArrowType.swift
+++ b/Sources/Arrow/ArrowType.swift
@@ -87,7 +87,7 @@ public enum ArrowTime64Unit {
 }
 
 public class ArrowTypeTime32: ArrowType {
-    let unit: ArrowTime32Unit
+    public let unit: ArrowTime32Unit
     public init(_ unit: ArrowTime32Unit) {
         self.unit = unit
         super.init(ArrowType.ArrowTime32)
@@ -106,7 +106,7 @@ public class ArrowTypeTime32: ArrowType {
 }
 
 public class ArrowTypeTime64: ArrowType {
-    let unit: ArrowTime64Unit
+    public let unit: ArrowTime64Unit
     public init(_ unit: ArrowTime64Unit) {
         self.unit = unit
         super.init(ArrowType.ArrowTime64)
@@ -132,8 +132,8 @@ public enum ArrowTimestampUnit {
 }
 
 public class ArrowTypeTimestamp: ArrowType {
-    let unit: ArrowTimestampUnit
-    let timezone: String?
+    public let unit: ArrowTimestampUnit
+    public let timezone: String?
 
     public init(_ unit: ArrowTimestampUnit, timezone: String? = nil) {
         self.unit = unit
@@ -166,7 +166,7 @@ public class ArrowTypeTimestamp: ArrowType {
 }
 
 public class ArrowTypeStruct: ArrowType {
-    let fields: [ArrowField]
+    public let fields: [ArrowField]
     public init(_ info: ArrowType.Info, fields: [ArrowField]) {
         self.fields = fields
         super.init(info)

--- a/Sources/ArrowJSONIntegrationTest/ArrowJSON+Normalize.swift
+++ b/Sources/ArrowJSONIntegrationTest/ArrowJSON+Normalize.swift
@@ -25,7 +25,7 @@ extension ArrowJSON {
         .init(
             schema: self.schema,
             batches: self.batches.map { batch in
-                    .init(count: batch.count, columns: batch.columns.map { $0.withoutPlaceholderValues() })
+                .init(count: batch.count, columns: batch.columns.map { $0.withoutPlaceholderValues() })
             },
             dictionaries: self.dictionaries
         )

--- a/Sources/ArrowJSONIntegrationTest/ArrowJSON+Normalize.swift
+++ b/Sources/ArrowJSONIntegrationTest/ArrowJSON+Normalize.swift
@@ -1,0 +1,33 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+extension ArrowJSON {
+
+    /// Strips per-null placeholder values from every column, recursively.
+    ///
+    /// This allows two semantically-equal files with different placeholder bytes in null slots
+    /// to still compare equal.
+    func normalized() -> ArrowJSON {
+        .init(
+            schema: self.schema,
+            batches: self.batches.map { batch in
+                    .init(count: batch.count, columns: batch.columns.map { $0.withoutPlaceholderValues() })
+            },
+            dictionaries: self.dictionaries
+        )
+    }
+}

--- a/Sources/ArrowJSONIntegrationTest/ArrowJSON.swift
+++ b/Sources/ArrowJSONIntegrationTest/ArrowJSON.swift
@@ -19,304 +19,304 @@ import Foundation
 
 /// The JSON file structure used Arrow test files.
 struct ArrowJSON: Codable, Equatable {
-  let schema: Schema
-  let batches: [Batch]
-  let dictionaries: [Dictionary]?
-
-  struct Dictionary: Codable, Equatable {
-    let id: Int
-    let data: Batch
-  }
-
-  struct DictionaryInfo: Codable, Equatable {
-    let id: Int
-    let indexType: FieldType
-    let isOrdered: Bool?
-  }
-
-  struct Schema: Codable, Equatable {
-    let fields: [Field]
-    let metadata: [String: String]?
-
-    enum CodingKeys: String, CodingKey {
-      case fields
-      case metadata
+    let schema: Schema
+    let batches: [Batch]
+    let dictionaries: [Dictionary]?
+    
+    struct Dictionary: Codable, Equatable {
+        let id: Int
+        let data: Batch
     }
-
-    init(fields: [Field], metadata: [String: String]?) {
-      self.fields = fields
-      self.metadata = metadata
+    
+    struct DictionaryInfo: Codable, Equatable {
+        let id: Int
+        let indexType: FieldType
+        let isOrdered: Bool?
     }
-
-    init(from decoder: Decoder) throws {
-      let container = try decoder.container(keyedBy: CodingKeys.self)
-      self.fields = try container.decode([Field].self, forKey: .fields)
-      if container.contains(.metadata) {
-        var metadataArray = try container.nestedUnkeyedContainer(
-          forKey: .metadata
-        )
-        try self.metadata = buildDictionary(from: &metadataArray)
-      } else {
-        self.metadata = nil
-      }
-    }
-  }
-
-  struct Field: Codable, Equatable {
-    let name: String
-    let type: FieldType
-    let nullable: Bool
-    let children: [Field]?
-    let dictionary: DictionaryInfo?
-    let metadata: [String: String]?
-
-    init(
-      name: String,
-      type: FieldType,
-      nullable: Bool,
-      children: [Field]? = nil,
-      dictionary: DictionaryInfo? = nil,
-      metadata: [String: String]? = nil
-    ) {
-      self.name = name
-      self.type = type
-      self.nullable = nullable
-      self.children = children
-      self.dictionary = dictionary
-      self.metadata = metadata
-    }
-
-    init(from decoder: Decoder) throws {
-      let container = try decoder.container(keyedBy: CodingKeys.self)
-      self.name = try container.decode(String.self, forKey: .name)
-      self.type = try container.decode(FieldType.self, forKey: .type)
-      self.nullable = try container.decode(Bool.self, forKey: .nullable)
-      self.children = try container.decodeIfPresent(
-        [Field].self,
-        forKey: .children
-      )
-      self.dictionary = try container.decodeIfPresent(
-        DictionaryInfo.self,
-        forKey: .dictionary
-      )
-      if container.contains(.metadata) {
-        var metadataArray = try container.nestedUnkeyedContainer(
-          forKey: .metadata
-        )
-        try self.metadata = buildDictionary(from: &metadataArray)
-      } else {
-        self.metadata = nil
-      }
-    }
-
-    enum CodingKeys: String, CodingKey {
-      case name
-      case type
-      case nullable
-      case children
-      case dictionary
-      case metadata
-    }
-  }
-
-  struct FieldType: Codable, Equatable {
-    let name: String
-    let byteWidth: Int?
-    let bitWidth: Int?
-    let isSigned: Bool?
-    let precision: String?
-    let scale: Int?
-    let unit: String?
-    let timezone: String?
-    let listSize: Int?
-  }
-
-  struct Batch: Codable, Equatable {
-    let count: Int
-    let columns: [Column]
-  }
-
-  struct Column: Codable, Equatable {
-    let name: String
-    let count: Int
-    let validity: [Int]?
-    let offset: [Int64]?  // Change to Int64 to handle large values
-    let data: [DataValue]?
-    let views: [View?]?
-    let variadicDataBuffers: [String]?
-    let children: [Column]?
-
-    enum CodingKeys: String, CodingKey {
-      case name
-      case count
-      case validity = "VALIDITY"
-      case offset = "OFFSET"
-      case data = "DATA"
-      case views = "VIEWS"
-      case variadicDataBuffers = "VARIADIC_DATA_BUFFERS"
-      case children
-    }
-
-    init(
-      name: String,
-      count: Int,
-      validity: [Int]? = nil,
-      offset: [Int64]? = nil,
-      data: [DataValue]? = nil,
-      views: [View?]? = nil,
-      variadicDataBuffers: [String]? = nil,
-      children: [Column]? = nil
-    ) {
-      self.name = name
-      self.count = count
-      self.validity = validity
-      self.offset = offset
-      self.data = data
-      self.views = views
-      self.variadicDataBuffers = variadicDataBuffers
-      self.children = children
-    }
-
-    // The custom decoder is required because 64 bit offsets are encoded
-    // as Strings presumably because some JSON libs can't handle it.
-    init(from decoder: Decoder) throws {
-      let container = try decoder.container(keyedBy: CodingKeys.self)
-      name = try container.decode(String.self, forKey: .name)
-      count = try container.decode(Int.self, forKey: .count)
-      validity = try container.decodeIfPresent([Int].self, forKey: .validity)
-      data = try container.decodeIfPresent([DataValue].self, forKey: .data)
-      views = try container.decodeIfPresent([View?].self, forKey: .views)
-      variadicDataBuffers = try container.decodeIfPresent(
-        [String].self, forKey: .variadicDataBuffers)
-      children = try container.decodeIfPresent([Column].self, forKey: .children)
-
-      // Decode offset as either [Int64] or [String], converting strings to Int64
-      if let offsetInts = try? container.decodeIfPresent(
-        [Int64].self, forKey: .offset) {
-        offset = offsetInts
-      } else if let offsetStrings = try? container.decodeIfPresent(
-        [String].self, forKey: .offset) {
-        offset = try offsetStrings.map { str in
-          guard let value = Int64(str) else {
-            throw DecodingError.dataCorruptedError(
-              forKey: .offset,
-              in: container,
-              debugDescription: "Invalid integer string: \(str)"
-            )
-          }
-          return value
+    
+    struct Schema: Codable, Equatable {
+        let fields: [Field]
+        let metadata: [String: String]?
+        
+        enum CodingKeys: String, CodingKey {
+            case fields
+            case metadata
         }
-      } else {
-        offset = nil
-      }
+        
+        init(fields: [Field], metadata: [String: String]?) {
+            self.fields = fields
+            self.metadata = metadata
+        }
+        
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.fields = try container.decode([Field].self, forKey: .fields)
+            if container.contains(.metadata) {
+                var metadataArray = try container.nestedUnkeyedContainer(
+                    forKey: .metadata
+                )
+                try self.metadata = buildDictionary(from: &metadataArray)
+            } else {
+                self.metadata = nil
+            }
+        }
     }
-  }
-
-  enum Value: Codable, Equatable {
-    case int(Int)
-    case string(String)
-    case bool(Bool)
-  }
+    
+    struct Field: Codable, Equatable {
+        let name: String
+        let type: FieldType
+        let nullable: Bool
+        let children: [Field]?
+        let dictionary: DictionaryInfo?
+        let metadata: [String: String]?
+        
+        init(
+            name: String,
+            type: FieldType,
+            nullable: Bool,
+            children: [Field]? = nil,
+            dictionary: DictionaryInfo? = nil,
+            metadata: [String: String]? = nil
+        ) {
+            self.name = name
+            self.type = type
+            self.nullable = nullable
+            self.children = children
+            self.dictionary = dictionary
+            self.metadata = metadata
+        }
+        
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.name = try container.decode(String.self, forKey: .name)
+            self.type = try container.decode(FieldType.self, forKey: .type)
+            self.nullable = try container.decode(Bool.self, forKey: .nullable)
+            self.children = try container.decodeIfPresent(
+                [Field].self,
+                forKey: .children
+            )
+            self.dictionary = try container.decodeIfPresent(
+                DictionaryInfo.self,
+                forKey: .dictionary
+            )
+            if container.contains(.metadata) {
+                var metadataArray = try container.nestedUnkeyedContainer(
+                    forKey: .metadata
+                )
+                try self.metadata = buildDictionary(from: &metadataArray)
+            } else {
+                self.metadata = nil
+            }
+        }
+        
+        enum CodingKeys: String, CodingKey {
+            case name
+            case type
+            case nullable
+            case children
+            case dictionary
+            case metadata
+        }
+    }
+    
+    struct FieldType: Codable, Equatable {
+        let name: String
+        let byteWidth: Int?
+        let bitWidth: Int?
+        let isSigned: Bool?
+        let precision: String?
+        let scale: Int?
+        let unit: String?
+        let timezone: String?
+        let listSize: Int?
+    }
+    
+    struct Batch: Codable, Equatable {
+        let count: Int
+        let columns: [Column]
+    }
+    
+    struct Column: Codable, Equatable {
+        let name: String
+        let count: Int
+        let validity: [Int]?
+        let offset: [Int64]?  // Change to Int64 to handle large values
+        let data: [DataValue]?
+        let views: [View?]?
+        let variadicDataBuffers: [String]?
+        let children: [Column]?
+        
+        enum CodingKeys: String, CodingKey {
+            case name
+            case count
+            case validity = "VALIDITY"
+            case offset = "OFFSET"
+            case data = "DATA"
+            case views = "VIEWS"
+            case variadicDataBuffers = "VARIADIC_DATA_BUFFERS"
+            case children
+        }
+        
+        init(
+            name: String,
+            count: Int,
+            validity: [Int]? = nil,
+            offset: [Int64]? = nil,
+            data: [DataValue]? = nil,
+            views: [View?]? = nil,
+            variadicDataBuffers: [String]? = nil,
+            children: [Column]? = nil
+        ) {
+            self.name = name
+            self.count = count
+            self.validity = validity
+            self.offset = offset
+            self.data = data
+            self.views = views
+            self.variadicDataBuffers = variadicDataBuffers
+            self.children = children
+        }
+        
+        // The custom decoder is required because 64 bit offsets are encoded
+        // as Strings presumably because some JSON libs can't handle it.
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            name = try container.decode(String.self, forKey: .name)
+            count = try container.decode(Int.self, forKey: .count)
+            validity = try container.decodeIfPresent([Int].self, forKey: .validity)
+            data = try container.decodeIfPresent([DataValue].self, forKey: .data)
+            views = try container.decodeIfPresent([View?].self, forKey: .views)
+            variadicDataBuffers = try container.decodeIfPresent(
+                [String].self, forKey: .variadicDataBuffers)
+            children = try container.decodeIfPresent([Column].self, forKey: .children)
+            
+            // Decode offset as either [Int64] or [String], converting strings to Int64
+            if let offsetInts = try? container.decodeIfPresent(
+                [Int64].self, forKey: .offset) {
+                offset = offsetInts
+            } else if let offsetStrings = try? container.decodeIfPresent(
+                [String].self, forKey: .offset) {
+                offset = try offsetStrings.map { str in
+                    guard let value = Int64(str) else {
+                        throw DecodingError.dataCorruptedError(
+                            forKey: .offset,
+                            in: container,
+                            debugDescription: "Invalid integer string: \(str)"
+                        )
+                    }
+                    return value
+                }
+            } else {
+                offset = nil
+            }
+        }
+    }
+    
+    enum Value: Codable, Equatable {
+        case int(Int)
+        case string(String)
+        case bool(Bool)
+    }
 }
 
 /// A metadata key-value entry.
 private struct KeyValue: Codable, Equatable, Hashable {
-  let key: String
-  let value: String
+    let key: String
+    let value: String
 }
 
 /// Arrow JSON files data values have variable types.
 enum DataValue: Codable, Equatable {
-  case string(String)
-  case int(Int)
-  case bool(Bool)
-  case null
-
-  init(from decoder: Decoder) throws {
-    let container = try decoder.singleValueContainer()
-
-    if container.decodeNil() {
-      self = .null
-    } else if let intValue = try? container.decode(Int.self) {
-      self = .int(intValue)
-    } else if let doubleValue = try? container.decode(Double.self) {
-      self = .string(String(doubleValue))
-    } else if let stringValue = try? container.decode(String.self) {
-      self = .string(stringValue)
-    } else if let boolValue = try? container.decode(Bool.self) {
-      self = .bool(boolValue)
-    } else {
-      throw DecodingError.typeMismatch(
-        DataValue.self,
-        DecodingError.Context(
-          codingPath: decoder.codingPath,
-          debugDescription: "Cannot decode DataValue")
-      )
+    case string(String)
+    case int(Int)
+    case bool(Bool)
+    case null
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        
+        if container.decodeNil() {
+            self = .null
+        } else if let intValue = try? container.decode(Int.self) {
+            self = .int(intValue)
+        } else if let doubleValue = try? container.decode(Double.self) {
+            self = .string(String(doubleValue))
+        } else if let stringValue = try? container.decode(String.self) {
+            self = .string(stringValue)
+        } else if let boolValue = try? container.decode(Bool.self) {
+            self = .bool(boolValue)
+        } else {
+            throw DecodingError.typeMismatch(
+                DataValue.self,
+                DecodingError.Context(
+                    codingPath: decoder.codingPath,
+                    debugDescription: "Cannot decode DataValue")
+            )
+        }
     }
-  }
 }
 
 /// Represents an inline value in a binary view or utf8 view.
 struct View: Codable, Equatable {
-
-  let size: Int32
-  let inlined: String?
-  let prefixHex: String?
-  let bufferIndex: Int32?
-  let offset: Int32?
-
-  // Inlined case (≤12 bytes)
-  init(size: Int32, inlined: String) {
-    self.size = size
-    self.inlined = inlined
-    self.prefixHex = nil
-    self.bufferIndex = nil
-    self.offset = nil
-  }
-
-  // Reference case (>12 bytes)
-  init(size: Int32, prefixHex: String, bufferIndex: Int32, offset: Int32) {
-    self.size = size
-    self.inlined = nil
-    self.prefixHex = prefixHex
-    self.bufferIndex = bufferIndex
-    self.offset = offset
-  }
-
-  enum CodingKeys: String, CodingKey {
-    case size = "SIZE"
-    case inlined = "INLINED"
-    case prefixHex = "PREFIX_HEX"
-    case bufferIndex = "BUFFER_INDEX"
-    case offset = "OFFSET"
-  }
+    
+    let size: Int32
+    let inlined: String?
+    let prefixHex: String?
+    let bufferIndex: Int32?
+    let offset: Int32?
+    
+    // Inlined case (≤12 bytes)
+    init(size: Int32, inlined: String) {
+        self.size = size
+        self.inlined = inlined
+        self.prefixHex = nil
+        self.bufferIndex = nil
+        self.offset = nil
+    }
+    
+    // Reference case (>12 bytes)
+    init(size: Int32, prefixHex: String, bufferIndex: Int32, offset: Int32) {
+        self.size = size
+        self.inlined = nil
+        self.prefixHex = prefixHex
+        self.bufferIndex = bufferIndex
+        self.offset = offset
+    }
+    
+    enum CodingKeys: String, CodingKey {
+        case size = "SIZE"
+        case inlined = "INLINED"
+        case prefixHex = "PREFIX_HEX"
+        case bufferIndex = "BUFFER_INDEX"
+        case offset = "OFFSET"
+    }
 }
 
 extension ArrowJSON.Column {
-
-  /// Filter for the valid values.
-  /// - Returns: The test column data with nulls in place of junk values.
-  func withoutPlaceholderValues() -> Self {
-    guard let validity = self.validity else {
-      fatalError()
+    
+    /// Filter for the valid values.
+    /// - Returns: The test column data with nulls in place of junk values.
+    func withoutPlaceholderValues() -> Self {
+        guard let validity = self.validity else {
+            fatalError()
+        }
+        let filteredData = data?.enumerated().map { index, value in
+            validity[index] == 1 ? value : .null
+        }
+        let filteredViews = views?.enumerated().map { index, value in
+            validity[index] == 1 ? value : nil
+        }
+        return Self(
+            name: name,
+            count: count,
+            validity: validity,
+            offset: offset,
+            data: filteredData,
+            views: filteredViews,
+            variadicDataBuffers: variadicDataBuffers,
+            children: children?.map { $0.withoutPlaceholderValues() }
+        )
     }
-    let filteredData = data?.enumerated().map { index, value in
-      validity[index] == 1 ? value : .null
-    }
-    let filteredViews = views?.enumerated().map { index, value in
-      validity[index] == 1 ? value : nil
-    }
-    return Self(
-      name: name,
-      count: count,
-      validity: validity,
-      offset: offset,
-      data: filteredData,
-      views: filteredViews,
-      variadicDataBuffers: variadicDataBuffers,
-      children: children?.map { $0.withoutPlaceholderValues() }
-    )
-  }
 }
 
 /// Decode a list of `KeyValue` to a dictionary.
@@ -326,10 +326,10 @@ extension ArrowJSON.Column {
 private func buildDictionary(
   from keyValues: inout any UnkeyedDecodingContainer
 ) throws -> [String: String]? {
-  var dict: [String: String] = [:]
-  while !keyValues.isAtEnd {
-    let pair = try keyValues.decode(KeyValue.self)
-    dict[pair.key] = pair.value
-  }
-  return dict.isEmpty ? nil : dict
+    var dict: [String: String] = [:]
+    while !keyValues.isAtEnd {
+        let pair = try keyValues.decode(KeyValue.self)
+        dict[pair.key] = pair.value
+    }
+    return dict.isEmpty ? nil : dict
 }

--- a/Sources/ArrowJSONIntegrationTest/ArrowJSON.swift
+++ b/Sources/ArrowJSONIntegrationTest/ArrowJSON.swift
@@ -1,0 +1,335 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import Foundation
+
+/// The JSON file structure used Arrow test files.
+struct ArrowJSON: Codable, Equatable {
+  let schema: Schema
+  let batches: [Batch]
+  let dictionaries: [Dictionary]?
+
+  struct Dictionary: Codable, Equatable {
+    let id: Int
+    let data: Batch
+  }
+
+  struct DictionaryInfo: Codable, Equatable {
+    let id: Int
+    let indexType: FieldType
+    let isOrdered: Bool?
+  }
+
+  struct Schema: Codable, Equatable {
+    let fields: [Field]
+    let metadata: [String: String]?
+
+    enum CodingKeys: String, CodingKey {
+      case fields
+      case metadata
+    }
+
+    init(fields: [Field], metadata: [String: String]?) {
+      self.fields = fields
+      self.metadata = metadata
+    }
+
+    init(from decoder: Decoder) throws {
+      let container = try decoder.container(keyedBy: CodingKeys.self)
+      self.fields = try container.decode([Field].self, forKey: .fields)
+      if container.contains(.metadata) {
+        var metadataArray = try container.nestedUnkeyedContainer(
+          forKey: .metadata
+        )
+        try self.metadata = buildDictionary(from: &metadataArray)
+      } else {
+        self.metadata = nil
+      }
+    }
+  }
+
+  struct Field: Codable, Equatable {
+    let name: String
+    let type: FieldType
+    let nullable: Bool
+    let children: [Field]?
+    let dictionary: DictionaryInfo?
+    let metadata: [String: String]?
+
+    init(
+      name: String,
+      type: FieldType,
+      nullable: Bool,
+      children: [Field]? = nil,
+      dictionary: DictionaryInfo? = nil,
+      metadata: [String: String]? = nil
+    ) {
+      self.name = name
+      self.type = type
+      self.nullable = nullable
+      self.children = children
+      self.dictionary = dictionary
+      self.metadata = metadata
+    }
+
+    init(from decoder: Decoder) throws {
+      let container = try decoder.container(keyedBy: CodingKeys.self)
+      self.name = try container.decode(String.self, forKey: .name)
+      self.type = try container.decode(FieldType.self, forKey: .type)
+      self.nullable = try container.decode(Bool.self, forKey: .nullable)
+      self.children = try container.decodeIfPresent(
+        [Field].self,
+        forKey: .children
+      )
+      self.dictionary = try container.decodeIfPresent(
+        DictionaryInfo.self,
+        forKey: .dictionary
+      )
+      if container.contains(.metadata) {
+        var metadataArray = try container.nestedUnkeyedContainer(
+          forKey: .metadata
+        )
+        try self.metadata = buildDictionary(from: &metadataArray)
+      } else {
+        self.metadata = nil
+      }
+    }
+
+    enum CodingKeys: String, CodingKey {
+      case name
+      case type
+      case nullable
+      case children
+      case dictionary
+      case metadata
+    }
+  }
+
+  struct FieldType: Codable, Equatable {
+    let name: String
+    let byteWidth: Int?
+    let bitWidth: Int?
+    let isSigned: Bool?
+    let precision: String?
+    let scale: Int?
+    let unit: String?
+    let timezone: String?
+    let listSize: Int?
+  }
+
+  struct Batch: Codable, Equatable {
+    let count: Int
+    let columns: [Column]
+  }
+
+  struct Column: Codable, Equatable {
+    let name: String
+    let count: Int
+    let validity: [Int]?
+    let offset: [Int64]?  // Change to Int64 to handle large values
+    let data: [DataValue]?
+    let views: [View?]?
+    let variadicDataBuffers: [String]?
+    let children: [Column]?
+
+    enum CodingKeys: String, CodingKey {
+      case name
+      case count
+      case validity = "VALIDITY"
+      case offset = "OFFSET"
+      case data = "DATA"
+      case views = "VIEWS"
+      case variadicDataBuffers = "VARIADIC_DATA_BUFFERS"
+      case children
+    }
+
+    init(
+      name: String,
+      count: Int,
+      validity: [Int]? = nil,
+      offset: [Int64]? = nil,
+      data: [DataValue]? = nil,
+      views: [View?]? = nil,
+      variadicDataBuffers: [String]? = nil,
+      children: [Column]? = nil
+    ) {
+      self.name = name
+      self.count = count
+      self.validity = validity
+      self.offset = offset
+      self.data = data
+      self.views = views
+      self.variadicDataBuffers = variadicDataBuffers
+      self.children = children
+    }
+
+    // The custom decoder is required because 64 bit offsets are encoded
+    // as Strings presumably because some JSON libs can't handle it.
+    init(from decoder: Decoder) throws {
+      let container = try decoder.container(keyedBy: CodingKeys.self)
+      name = try container.decode(String.self, forKey: .name)
+      count = try container.decode(Int.self, forKey: .count)
+      validity = try container.decodeIfPresent([Int].self, forKey: .validity)
+      data = try container.decodeIfPresent([DataValue].self, forKey: .data)
+      views = try container.decodeIfPresent([View?].self, forKey: .views)
+      variadicDataBuffers = try container.decodeIfPresent(
+        [String].self, forKey: .variadicDataBuffers)
+      children = try container.decodeIfPresent([Column].self, forKey: .children)
+
+      // Decode offset as either [Int64] or [String], converting strings to Int64
+      if let offsetInts = try? container.decodeIfPresent(
+        [Int64].self, forKey: .offset) {
+        offset = offsetInts
+      } else if let offsetStrings = try? container.decodeIfPresent(
+        [String].self, forKey: .offset) {
+        offset = try offsetStrings.map { str in
+          guard let value = Int64(str) else {
+            throw DecodingError.dataCorruptedError(
+              forKey: .offset,
+              in: container,
+              debugDescription: "Invalid integer string: \(str)"
+            )
+          }
+          return value
+        }
+      } else {
+        offset = nil
+      }
+    }
+  }
+
+  enum Value: Codable, Equatable {
+    case int(Int)
+    case string(String)
+    case bool(Bool)
+  }
+}
+
+/// A metadata key-value entry.
+private struct KeyValue: Codable, Equatable, Hashable {
+  let key: String
+  let value: String
+}
+
+/// Arrow JSON files data values have variable types.
+enum DataValue: Codable, Equatable {
+  case string(String)
+  case int(Int)
+  case bool(Bool)
+  case null
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+
+    if container.decodeNil() {
+      self = .null
+    } else if let intValue = try? container.decode(Int.self) {
+      self = .int(intValue)
+    } else if let doubleValue = try? container.decode(Double.self) {
+      self = .string(String(doubleValue))
+    } else if let stringValue = try? container.decode(String.self) {
+      self = .string(stringValue)
+    } else if let boolValue = try? container.decode(Bool.self) {
+      self = .bool(boolValue)
+    } else {
+      throw DecodingError.typeMismatch(
+        DataValue.self,
+        DecodingError.Context(
+          codingPath: decoder.codingPath,
+          debugDescription: "Cannot decode DataValue")
+      )
+    }
+  }
+}
+
+/// Represents an inline value in a binary view or utf8 view.
+struct View: Codable, Equatable {
+
+  let size: Int32
+  let inlined: String?
+  let prefixHex: String?
+  let bufferIndex: Int32?
+  let offset: Int32?
+
+  // Inlined case (≤12 bytes)
+  init(size: Int32, inlined: String) {
+    self.size = size
+    self.inlined = inlined
+    self.prefixHex = nil
+    self.bufferIndex = nil
+    self.offset = nil
+  }
+
+  // Reference case (>12 bytes)
+  init(size: Int32, prefixHex: String, bufferIndex: Int32, offset: Int32) {
+    self.size = size
+    self.inlined = nil
+    self.prefixHex = prefixHex
+    self.bufferIndex = bufferIndex
+    self.offset = offset
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case size = "SIZE"
+    case inlined = "INLINED"
+    case prefixHex = "PREFIX_HEX"
+    case bufferIndex = "BUFFER_INDEX"
+    case offset = "OFFSET"
+  }
+}
+
+extension ArrowJSON.Column {
+
+  /// Filter for the valid values.
+  /// - Returns: The test column data with nulls in place of junk values.
+  func withoutPlaceholderValues() -> Self {
+    guard let validity = self.validity else {
+      fatalError()
+    }
+    let filteredData = data?.enumerated().map { index, value in
+      validity[index] == 1 ? value : .null
+    }
+    let filteredViews = views?.enumerated().map { index, value in
+      validity[index] == 1 ? value : nil
+    }
+    return Self(
+      name: name,
+      count: count,
+      validity: validity,
+      offset: offset,
+      data: filteredData,
+      views: filteredViews,
+      variadicDataBuffers: variadicDataBuffers,
+      children: children?.map { $0.withoutPlaceholderValues() }
+    )
+  }
+}
+
+/// Decode a list of `KeyValue` to a dictionary.
+/// - Parameter keyValues: The key values to convert.
+/// - Throws: If decoding fails.
+/// - Returns: A metadata dictionary.
+private func buildDictionary(
+  from keyValues: inout any UnkeyedDecodingContainer
+) throws -> [String: String]? {
+  var dict: [String: String] = [:]
+  while !keyValues.isAtEnd {
+    let pair = try keyValues.decode(KeyValue.self)
+    dict[pair.key] = pair.value
+  }
+  return dict.isEmpty ? nil : dict
+}

--- a/Sources/ArrowJSONIntegrationTest/ArrowJSON.swift
+++ b/Sources/ArrowJSONIntegrationTest/ArrowJSON.swift
@@ -22,32 +22,32 @@ struct ArrowJSON: Codable, Equatable {
     let schema: Schema
     let batches: [Batch]
     let dictionaries: [Dictionary]?
-    
+
     struct Dictionary: Codable, Equatable {
         let id: Int
         let data: Batch
     }
-    
+
     struct DictionaryInfo: Codable, Equatable {
         let id: Int
         let indexType: FieldType
         let isOrdered: Bool?
     }
-    
+
     struct Schema: Codable, Equatable {
         let fields: [Field]
         let metadata: [String: String]?
-        
+
         enum CodingKeys: String, CodingKey {
             case fields
             case metadata
         }
-        
+
         init(fields: [Field], metadata: [String: String]?) {
             self.fields = fields
             self.metadata = metadata
         }
-        
+
         init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             self.fields = try container.decode([Field].self, forKey: .fields)
@@ -61,7 +61,7 @@ struct ArrowJSON: Codable, Equatable {
             }
         }
     }
-    
+
     struct Field: Codable, Equatable {
         let name: String
         let type: FieldType
@@ -69,7 +69,7 @@ struct ArrowJSON: Codable, Equatable {
         let children: [Field]?
         let dictionary: DictionaryInfo?
         let metadata: [String: String]?
-        
+
         init(
             name: String,
             type: FieldType,
@@ -85,7 +85,7 @@ struct ArrowJSON: Codable, Equatable {
             self.dictionary = dictionary
             self.metadata = metadata
         }
-        
+
         init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             self.name = try container.decode(String.self, forKey: .name)
@@ -108,7 +108,7 @@ struct ArrowJSON: Codable, Equatable {
                 self.metadata = nil
             }
         }
-        
+
         enum CodingKeys: String, CodingKey {
             case name
             case type
@@ -118,7 +118,7 @@ struct ArrowJSON: Codable, Equatable {
             case metadata
         }
     }
-    
+
     struct FieldType: Codable, Equatable {
         let name: String
         let byteWidth: Int?
@@ -130,12 +130,12 @@ struct ArrowJSON: Codable, Equatable {
         let timezone: String?
         let listSize: Int?
     }
-    
+
     struct Batch: Codable, Equatable {
         let count: Int
         let columns: [Column]
     }
-    
+
     struct Column: Codable, Equatable {
         let name: String
         let count: Int
@@ -145,7 +145,7 @@ struct ArrowJSON: Codable, Equatable {
         let views: [View?]?
         let variadicDataBuffers: [String]?
         let children: [Column]?
-        
+
         enum CodingKeys: String, CodingKey {
             case name
             case count
@@ -156,7 +156,7 @@ struct ArrowJSON: Codable, Equatable {
             case variadicDataBuffers = "VARIADIC_DATA_BUFFERS"
             case children
         }
-        
+
         init(
             name: String,
             count: Int,
@@ -176,7 +176,7 @@ struct ArrowJSON: Codable, Equatable {
             self.variadicDataBuffers = variadicDataBuffers
             self.children = children
         }
-        
+
         // The custom decoder is required because 64 bit offsets are encoded
         // as Strings presumably because some JSON libs can't handle it.
         init(from decoder: Decoder) throws {
@@ -189,13 +189,13 @@ struct ArrowJSON: Codable, Equatable {
             variadicDataBuffers = try container.decodeIfPresent(
                 [String].self, forKey: .variadicDataBuffers)
             children = try container.decodeIfPresent([Column].self, forKey: .children)
-            
+
             // Decode offset as either [Int64] or [String], converting strings to Int64
             if let offsetInts = try? container.decodeIfPresent(
                 [Int64].self, forKey: .offset) {
                 offset = offsetInts
             } else if let offsetStrings = try? container.decodeIfPresent(
-                [String].self, forKey: .offset) {
+                        [String].self, forKey: .offset) {
                 offset = try offsetStrings.map { str in
                     guard let value = Int64(str) else {
                         throw DecodingError.dataCorruptedError(
@@ -211,7 +211,7 @@ struct ArrowJSON: Codable, Equatable {
             }
         }
     }
-    
+
     enum Value: Codable, Equatable {
         case int(Int)
         case string(String)
@@ -231,10 +231,9 @@ enum DataValue: Codable, Equatable {
     case int(Int)
     case bool(Bool)
     case null
-    
+
     init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        
         if container.decodeNil() {
             self = .null
         } else if let intValue = try? container.decode(Int.self) {
@@ -258,13 +257,13 @@ enum DataValue: Codable, Equatable {
 
 /// Represents an inline value in a binary view or utf8 view.
 struct View: Codable, Equatable {
-    
+
     let size: Int32
     let inlined: String?
     let prefixHex: String?
     let bufferIndex: Int32?
     let offset: Int32?
-    
+
     // Inlined case (≤12 bytes)
     init(size: Int32, inlined: String) {
         self.size = size
@@ -273,7 +272,7 @@ struct View: Codable, Equatable {
         self.bufferIndex = nil
         self.offset = nil
     }
-    
+
     // Reference case (>12 bytes)
     init(size: Int32, prefixHex: String, bufferIndex: Int32, offset: Int32) {
         self.size = size
@@ -282,7 +281,7 @@ struct View: Codable, Equatable {
         self.bufferIndex = bufferIndex
         self.offset = offset
     }
-    
+
     enum CodingKeys: String, CodingKey {
         case size = "SIZE"
         case inlined = "INLINED"
@@ -293,7 +292,7 @@ struct View: Codable, Equatable {
 }
 
 extension ArrowJSON.Column {
-    
+
     /// Filter for the valid values.
     /// - Returns: The test column data with nulls in place of junk values.
     func withoutPlaceholderValues() -> Self {
@@ -324,7 +323,7 @@ extension ArrowJSON.Column {
 /// - Throws: If decoding fails.
 /// - Returns: A metadata dictionary.
 private func buildDictionary(
-  from keyValues: inout any UnkeyedDecodingContainer
+    from keyValues: inout any UnkeyedDecodingContainer
 ) throws -> [String: String]? {
     var dict: [String: String] = [:]
     while !keyValues.isAtEnd {

--- a/Sources/ArrowJSONIntegrationTest/ArrowJSONIntegrationTest+Decode.swift
+++ b/Sources/ArrowJSONIntegrationTest/ArrowJSONIntegrationTest+Decode.swift
@@ -98,8 +98,8 @@ extension ArrowJSONIntegrationTest {
                 throw ArrowError.invalid("time type missing bitWidth/unit")
             }
             return bitWidth == 32
-            ? ArrowTypeTime32(unit == "SECOND" ? .seconds : .milliseconds)
-            : ArrowTypeTime64(unit == "MICROSECOND" ? .microseconds : .nanoseconds)
+                ? ArrowTypeTime32(unit == "SECOND" ? .seconds : .milliseconds)
+                : ArrowTypeTime64(unit == "MICROSECOND" ? .microseconds : .nanoseconds)
 
         case "timestamp":
             guard let unit = field.type.unit else {
@@ -242,9 +242,6 @@ extension ArrowJSONIntegrationTest {
             return (fieldType(name: "floatingpoint", precision: "SINGLE"), nil)
         case .double:
             return (fieldType(name: "floatingpoint", precision: "DOUBLE"), nil)
-            // NOTE: no .float16 case — ArrowTypeId's HalfFloat case is commented out
-            // upstream, so the official library doesn't support it yet.
-
         case .string:
             return (fieldType(name: "utf8"), nil)
         case .binary:

--- a/Sources/ArrowJSONIntegrationTest/ArrowJSONIntegrationTest+Decode.swift
+++ b/Sources/ArrowJSONIntegrationTest/ArrowJSONIntegrationTest+Decode.swift
@@ -1,0 +1,326 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import Foundation
+import Arrow
+
+extension ArrowJSONIntegrationTest {
+
+    /// Reads an Arrow IPC file and encodes it into the gold JSON model.
+    func decodeArrowJSON(from arrowURL: URL) throws -> ArrowJSON {
+        let result: ArrowReader.ArrowReaderResult
+        switch ArrowReader().fromFile(arrowURL) {
+        case .success(let res): result = res
+        case .failure(let error): throw error
+        }
+
+        guard let schema = result.schema else {
+            throw ArrowError.invalid("Arrow file is missing a schema")
+        }
+
+        return ArrowJSON(
+            schema: try encodeSchema(schema),
+            batches: try encode(batches: result.batches, schema: schema),
+            dictionaries: nil
+        )
+    }
+
+    func buildHolder(column: ArrowJSON.Column, type: ArrowType) throws -> ArrowArrayHolder {
+        let builder = try ArrowArrayBuilders.loadBuilder(arrowType: type)
+        let data = column.data ?? []
+        let validity = column.validity ?? Array(repeating: 1, count: column.count)
+
+        for idx in 0..<column.count {
+            if validity[idx] == 0 {
+                builder.appendAny(nil)
+            } else {
+                builder.appendAny(try nativeValue(data[idx], typeId: type.id))
+            }
+        }
+        return try builder.toHolder()
+    }
+
+    /// Reconstructs an `ArrowType` from the JSON type object.
+    func decodeArrowType(_ field: ArrowJSON.Field) throws -> ArrowType {
+        switch field.type.name {
+        case "bool":
+            return ArrowType(ArrowType.ArrowBool)
+
+        case "int":
+            guard let bitWidth = field.type.bitWidth, let isSigned = field.type.isSigned else {
+                throw ArrowError.invalid("int type missing bitWidth/isSigned")
+            }
+            switch (bitWidth, isSigned) {
+            case (8, true): return ArrowType(ArrowType.ArrowInt8)
+            case (16, true): return ArrowType(ArrowType.ArrowInt16)
+            case (32, true): return ArrowType(ArrowType.ArrowInt32)
+            case (64, true): return ArrowType(ArrowType.ArrowInt64)
+            case (8, false): return ArrowType(ArrowType.ArrowUInt8)
+            case (16, false): return ArrowType(ArrowType.ArrowUInt16)
+            case (32, false): return ArrowType(ArrowType.ArrowUInt32)
+            case (64, false): return ArrowType(ArrowType.ArrowUInt64)
+            default: throw ArrowError.invalid("Unsupported int width \(bitWidth)")
+            }
+
+        case "floatingpoint":
+            switch field.type.precision {
+            case "SINGLE": return ArrowType(ArrowType.ArrowFloat)
+            case "DOUBLE": return ArrowType(ArrowType.ArrowDouble)
+            default: throw ArrowError.notImplemented  // HALF: no float16 support upstream yet
+            }
+
+        case "utf8": return ArrowType(ArrowType.ArrowString)
+        case "binary": return ArrowType(ArrowType.ArrowBinary)
+
+        case "date":
+            switch field.type.unit {
+            case "DAY": return ArrowType(ArrowType.ArrowDate32)
+            case "MILLISECOND": return ArrowType(ArrowType.ArrowDate64)
+            default: throw ArrowError.invalid("Unknown date unit")
+            }
+
+        case "time":
+            guard let bitWidth = field.type.bitWidth, let unit = field.type.unit else {
+                throw ArrowError.invalid("time type missing bitWidth/unit")
+            }
+            return bitWidth == 32
+            ? ArrowTypeTime32(unit == "SECOND" ? .seconds : .milliseconds)
+            : ArrowTypeTime64(unit == "MICROSECOND" ? .microseconds : .nanoseconds)
+
+        case "timestamp":
+            guard let unit = field.type.unit else {
+                throw ArrowError.invalid("timestamp type missing unit")
+            }
+            let tsUnit: ArrowTimestampUnit
+            switch unit {
+            case "SECOND": tsUnit = .seconds
+            case "MILLISECOND": tsUnit = .milliseconds
+            case "MICROSECOND": tsUnit = .microseconds
+            case "NANOSECOND": tsUnit = .nanoseconds
+            default: throw ArrowError.invalid("Unknown timestamp unit \(unit)")
+            }
+            return ArrowTypeTimestamp(tsUnit, timezone: field.type.timezone)
+
+        default:
+            // struct and list deferred.
+            throw ArrowError.notImplemented
+        }
+    }
+
+    func nativeValue(_ value: DataValue, typeId: ArrowTypeId) throws -> Any? {
+        func intVal() throws -> Int {
+            guard case .int(let intVal) = value else {
+                throw ArrowError.invalid("Expected int, got \(value)")
+            }
+            return intVal
+        }
+        func strVal() throws -> String {
+            guard case .string(let strVal) = value else {
+                throw ArrowError.invalid("Expected string, got \(value)")
+            }
+            return strVal
+        }
+        func exact<T: FixedWidthInteger>(_ type: T.Type) throws -> T {
+            let intVal = try intVal()
+            guard let val = T(exactly: intVal) else {
+                throw ArrowError.invalid("\(intVal) doesn't fit in \(T.self)")
+            }
+            return val
+        }
+
+        switch typeId {
+        case .boolean:
+            guard case .bool(let val) = value else {
+                throw ArrowError.invalid("Expected bool, got \(value)")
+            }
+            return val
+        case .int8: return try exact(Int8.self)
+        case .int16: return try exact(Int16.self)
+        case .int32: return try exact(Int32.self)
+        case .int64: return Int64(try strVal())
+        case .uint8: return try exact(UInt8.self)
+        case .uint16: return try exact(UInt16.self)
+        case .uint32: return try exact(UInt32.self)
+        case .uint64: return UInt64(try strVal())
+        // Arrow JSON floats decode to .string, see DataValue
+        case .float: return Float(try strVal())
+        case .double: return Double(try strVal())
+        case .string:
+            guard case .string(let str) = value else {
+                throw ArrowError.invalid("Expected string, got \(value)")
+            }
+            return str
+        case .binary:
+            guard case .string(let hex) = value else { throw ArrowError.invalid("Expected hex string") }
+            var data = Data(capacity: hex.count / 2)
+            var idx = hex.startIndex
+            while idx < hex.endIndex {
+                let next = hex.index(idx, offsetBy: 2)
+                if let byte = UInt8(hex[idx..<next], radix: 16) { data.append(byte) }
+                idx = next
+            }
+            return data
+        case .date32:
+            return Date(timeIntervalSince1970: Double(try intVal()) * 86_400)
+        case .date64:
+            return Date(timeIntervalSince1970: Double(Int64(try strVal()) ?? 0) / 1000)
+        case .time32:
+            return Int32(try intVal())
+        case .time64, .timestamp:
+            return Int64(try strVal()) ?? 0
+        default:
+            throw ArrowError.notImplemented
+        }
+    }
+
+    func encodeSchema(_ schema: ArrowSchema) throws -> ArrowJSON.Schema {
+        .init(fields: try schema.fields.map(encodeField), metadata: nil)
+    }
+
+    func encodeField(_ field: ArrowField) throws -> ArrowJSON.Field {
+        let (type, children) = try encodeFieldType(field.type)
+        return .init(
+            name: field.name,
+            type: type,
+            nullable: field.isNullable,
+            children: children ?? []
+        )
+    }
+
+    /// Returns the JSON `type` object plus, for nested types, the child fields
+    /// (structs get one child per member; lists get a single "item" child).
+    func encodeFieldType(
+        _ type: ArrowType
+    ) throws -> (ArrowJSON.FieldType, [ArrowJSON.Field]?) {
+        func fieldType(
+            name: String,
+            byteWidth: Int? = nil,
+            bitWidth: Int? = nil,
+            isSigned: Bool? = nil,
+            precision: String? = nil,
+            scale: Int? = nil,
+            unit: String? = nil,
+            timezone: String? = nil,
+            listSize: Int? = nil
+        ) -> ArrowJSON.FieldType {
+            .init(
+                name: name,
+                byteWidth: byteWidth,
+                bitWidth: bitWidth,
+                isSigned: isSigned,
+                precision: precision,
+                scale: scale,
+                unit: unit,
+                timezone: timezone,
+                listSize: listSize
+            )
+        }
+
+        switch type.id {
+        case .boolean:
+            return (fieldType(name: "bool"), nil)
+
+        case .int8, .int16, .int32, .int64, .uint8, .uint16, .uint32, .uint64:
+            let (bitWidth, isSigned) = intWidthAndSign(type.id)
+            return (fieldType(name: "int", bitWidth: bitWidth, isSigned: isSigned), nil)
+
+        case .float:
+            return (fieldType(name: "floatingpoint", precision: "SINGLE"), nil)
+        case .double:
+            return (fieldType(name: "floatingpoint", precision: "DOUBLE"), nil)
+            // NOTE: no .float16 case — ArrowTypeId's HalfFloat case is commented out
+            // upstream, so the official library doesn't support it yet.
+
+        case .string:
+            return (fieldType(name: "utf8"), nil)
+        case .binary:
+            return (fieldType(name: "binary"), nil)
+        case .date32:
+            return (fieldType(name: "date", unit: "DAY"), nil)
+        case .date64:
+            return (fieldType(name: "date", unit: "MILLISECOND"), nil)
+        case .time32:
+            guard let time32 = type as? ArrowTypeTime32 else {
+                throw ArrowError.invalid("Expected ArrowTypeTime32")
+            }
+            let unit = time32.unit == .seconds ? "SECOND" : "MILLISECOND"
+            return (fieldType(name: "time", bitWidth: 32, unit: unit), nil)
+
+        case .time64:
+            guard let time64 = type as? ArrowTypeTime64 else {
+                throw ArrowError.invalid("Expected ArrowTypeTime64")
+            }
+            let unit = time64.unit == .microseconds ? "MICROSECOND" : "NANOSECOND"
+            return (fieldType(name: "time", bitWidth: 64, unit: unit), nil)
+
+        case .timestamp:
+            guard let timeStamp = type as? ArrowTypeTimestamp else {
+                throw ArrowError.invalid("Expected ArrowTypeTimestamp")
+            }
+            let unit: String
+            switch timeStamp.unit {
+            case .seconds: unit = "SECOND"
+            case .milliseconds: unit = "MILLISECOND"
+            case .microseconds: unit = "MICROSECOND"
+            case .nanoseconds: unit = "NANOSECOND"
+            }
+            return (fieldType(name: "timestamp", unit: unit, timezone: timeStamp.timezone), nil)
+
+        case .strct:
+            guard let structType = type as? ArrowTypeStruct else {
+                throw ArrowError.invalid("Expected ArrowTypeStruct")
+            }
+            return (fieldType(name: "struct"), try structType.fields.map(encodeField))
+
+        case .list:
+            guard let listType = type as? ArrowTypeList else {
+                throw ArrowError.invalid("Expected ArrowTypeList")
+            }
+            return (fieldType(name: "list"), [try encodeField(listType.elementField)])
+
+        default:
+            throw ArrowError.notImplemented
+        }
+    }
+
+    private func intWidthAndSign(_ id: ArrowTypeId) -> (Int, Bool) {
+        switch id {
+        case .int8: return (8, true)
+        case .int16: return (16, true)
+        case .int32: return (32, true)
+        case .int64: return (64, true)
+        case .uint8: return (8, false)
+        case .uint16: return (16, false)
+        case .uint32: return (32, false)
+        case .uint64: return (64, false)
+        default: fatalError("Not an integer type")
+        }
+    }
+
+    func encode(
+        batches: [RecordBatch],
+        schema: ArrowSchema
+    ) throws -> [ArrowJSON.Batch] {
+        try batches.map { recordBatch in
+            let columns = try schema.fields.enumerated().map { index, field in
+                try encodeColumn(holder: recordBatch.column(index), field: field)
+            }
+            return .init(count: Int(recordBatch.length), columns: columns)
+        }
+    }
+
+}

--- a/Sources/ArrowJSONIntegrationTest/ArrowJSONIntegrationTest+Encode.swift
+++ b/Sources/ArrowJSONIntegrationTest/ArrowJSONIntegrationTest+Encode.swift
@@ -1,0 +1,175 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import Arrow
+import Foundation
+
+extension ArrowJSONIntegrationTest {
+
+    /// Encode a column (array + field) to the Arrow testing JSON format.
+    func encodeColumn(
+        holder: ArrowArrayHolder,
+        field: ArrowField
+    ) throws -> ArrowJSON.Column {
+
+        let arrowData = holder.data
+
+        let length = Int(holder.length)
+        let indices = (UInt(0)..<UInt(length))
+
+        // Validity is always present in the Arrow JSON files.
+        let validity: [Int] = indices.map { arrowData.isNull($0) ? 0 : 1 }
+
+        var offsets: [Int64]?
+        var dataValue: [DataValue]? = []
+        var children: [ArrowJSON.Column]?
+
+        switch field.type.id {
+        case .boolean:
+            guard let arr = holder.array as? BoolArray else {
+                throw ArrowError.invalid("Expected BoolArray")
+            }
+            dataValue = indices.map { arr[$0].map(DataValue.bool) ?? .null }
+
+        case .int8:
+            dataValue = try extractFixedData(holder.array, indices: indices, as: Int8.self)
+        case .int16:
+            dataValue = try extractFixedData(holder.array, indices: indices, as: Int16.self)
+        case .int32:
+            dataValue = try extractFixedData(holder.array, indices: indices, as: Int32.self)
+        case .int64:
+            dataValue = try extractFixedData(
+                holder.array, indices: indices, as: Int64.self, as64BitString: true)
+        case .uint8:
+            dataValue = try extractFixedData(holder.array, indices: indices, as: UInt8.self)
+        case .uint16:
+            dataValue = try extractFixedData(holder.array, indices: indices, as: UInt16.self)
+        case .uint32:
+            dataValue = try extractFixedData(holder.array, indices: indices, as: UInt32.self)
+        case .uint64:
+            dataValue = try extractFixedData(
+                holder.array, indices: indices, as: UInt64.self, as64BitString: true)
+        case .float:
+            dataValue = try extractFloatData(holder.array, indices: indices, as: Float.self)
+        case .double:
+            dataValue = try extractFloatData(holder.array, indices: indices, as: Double.self)
+        case .date32:
+            guard let arr = holder.array as? Date32Array else {
+                throw ArrowError.invalid("Expected Date32Array")
+            }
+            dataValue = indices.map { idx in
+                guard let date = arr[idx] else { return .null }
+                return .int(Int((date.timeIntervalSince1970 / 86_400).rounded()))
+            }
+        case .date64:
+            guard let arr = holder.array as? Date64Array else {
+                throw ArrowError.invalid("Expected Date64Array")
+            }
+            dataValue = indices.map { idx in
+                guard let date = arr[idx] else { return .null }
+                let millis = Int64((date.timeIntervalSince1970 * 1000).rounded())
+                return .string("\(millis)")
+            }
+        case .time32:
+            dataValue = try extractFixedData(holder.array, indices: indices, as: Int32.self)
+        case .time64:
+            dataValue = try extractFixedData(
+                holder.array, indices: indices, as: Int64.self, as64BitString: true)
+        case .timestamp:
+            dataValue = try extractFixedData(
+                holder.array, indices: indices, as: Int64.self, as64BitString: true)
+        case .string:
+            guard let arr = holder.array as? StringArray else {
+                throw ArrowError.invalid("Expected StringArray")
+            }
+            offsets = try readInt32Offsets(arrowData, count: length)
+            dataValue = indices.map { arr[$0].map(DataValue.string) ?? .null }
+
+        case .binary:
+            guard let arr = holder.array as? BinaryArray else {
+                throw ArrowError.invalid("Expected BinaryArray")
+            }
+            offsets = try readInt32Offsets(arrowData, count: length)
+            dataValue = indices.map { idx in
+                guard let val = arr[idx] else { return .null }
+                return .string(val.map { String(format: "%02X", $0) }.joined())
+            }
+
+        case .strct:
+            throw ArrowError.notImplemented
+        case .list:
+            throw ArrowError.notImplemented
+        default:
+            throw ArrowError.notImplemented
+        }
+
+        return .init(
+            name: field.name,
+            count: length,
+            validity: validity,
+            offset: offsets,
+            data: dataValue,
+            children: children
+        )
+    }
+
+    // MARK: - Helpers
+
+    func extractFixedData<T: FixedWidthInteger>(
+        _ array: AnyArray,
+        indices: Range<UInt>,
+        as type: T.Type,
+        as64BitString: Bool = false
+    ) throws -> [DataValue] {
+        guard let arr = array as? ArrowArray<T> else {
+            throw ArrowError.invalid("Expected ArrowArray<\(T.self)>")
+        }
+        return indices.map { idx in
+            guard let val = arr[idx] else { return .null }
+            return as64BitString ? .string("\(val)") : .int(Int(val))
+        }
+    }
+
+    func extractFloatData<T: BinaryFloatingPoint & Codable>(
+        _ array: AnyArray,
+        indices: Range<UInt>,
+        as type: T.Type
+    ) throws -> [DataValue] {
+        guard let arr = array as? ArrowArray<T> else {
+            throw ArrowError.invalid("Expected ArrowArray<\(T.self)>")
+        }
+        let encoder = JSONEncoder()
+        let decoder = JSONDecoder()
+        return try indices.map { idx in
+            guard let value = arr[idx] else { return .null }
+            let jsonNumber = try decoder.decode(T.self, from: encoder.encode(value))
+            return .string("\(jsonNumber)")
+        }
+    }
+
+    func readInt32Offsets(_ arrowData: ArrowData, count: Int) throws -> [Int64] {
+        guard arrowData.buffers.count > 1 else {
+            throw ArrowError.invalid("Missing offsets buffer")
+        }
+        let offsetsBuffer = arrowData.buffers[1]
+        return (0...count).map { idx in
+            Int64(
+                offsetsBuffer.rawPointer.advanced(by: idx * MemoryLayout<Int32>.stride)
+                    .load(as: Int32.self))
+        }
+    }
+}

--- a/Sources/ArrowJSONIntegrationTest/ArrowJSONIntegrationTest.swift
+++ b/Sources/ArrowJSONIntegrationTest/ArrowJSONIntegrationTest.swift
@@ -1,0 +1,128 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ArgumentParser
+import Arrow
+import Foundation
+
+enum IntegrationMode: String, ExpressibleByArgument, CaseIterable {
+  case arrowToJson = "ARROW_TO_JSON"
+  case jsonToArrow = "JSON_TO_ARROW"
+  case validate = "VALIDATE"
+}
+
+@main
+struct ArrowJSONIntegrationTest: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "arrow-json-integration-test",
+        abstract: "Converts between and validates Arrow and JSON integration test files."
+    )
+
+    @Option(name: .long, help: "Path to the Arrow file.")
+    var arrow: String
+
+    @Option(name: .long, help: "Path to the JSON file.")
+    var json: String
+
+    @Option(name: .long, help: "Mode: ARROW_TO_JSON, JSON_TO_ARROW, or VALIDATE.")
+    var mode: IntegrationMode
+
+    func validate() throws {
+        // Runs automatically before `run()` — good place for input checks.
+        if mode != .jsonToArrow {
+            guard FileManager.default.fileExists(atPath: arrow) else {
+                throw ValidationError("Arrow file not found at path: \(arrow)")
+            }
+        }
+        if mode != .arrowToJson {
+            guard FileManager.default.fileExists(atPath: json) else {
+                throw ValidationError("JSON file not found at path: \(json)")
+            }
+        }
+    }
+
+    func run() throws {
+        let arrowURL = URL(fileURLWithPath: arrow)
+        let jsonURL = URL(fileURLWithPath: json)
+
+        switch mode {
+        case .arrowToJson:
+            try convertArrowToJSON(arrowURL: arrowURL, jsonURL: jsonURL)
+        case .jsonToArrow:
+            try convertJSONToArrow(jsonURL: jsonURL, arrowURL: arrowURL)
+        case .validate:
+            try validateFiles(arrowURL: arrowURL, jsonURL: jsonURL)
+        }
+    }
+
+    private func convertJSONToArrow(jsonURL: URL, arrowURL: URL) throws {
+        let arrowJSON = try JSONDecoder().decode(ArrowJSON.self, from: try Data(contentsOf: jsonURL))
+        let jsonFields = arrowJSON.schema.fields  // [ArrowJSON.Field]
+        let arrowFields = try jsonFields.map(decodeField)  // [ArrowField]
+
+        var batches: [RecordBatch] = []
+        for batch in arrowJSON.batches {
+            let builder = RecordBatch.Builder()
+            for (jsonField, arrowField) in zip(jsonFields, arrowFields) {
+                guard let column = batch.columns.first(where: { $0.name == jsonField.name }) else {
+                    throw ArrowError.invalid("Missing column \(jsonField.name)")
+                }
+                _ = builder.addColumn(
+                    arrowField.name,
+                    arrowArray: try buildHolder(column: column, type: arrowField.type))
+            }
+            switch builder.finish() {
+            case .success(let recordBatch): batches.append(recordBatch)
+            case .failure(let error): throw error
+            }
+        }
+
+        let schemaBuilder = ArrowSchema.Builder()
+        for arrowField in arrowFields {
+            schemaBuilder.addField(arrowField)
+        }
+        let schema = schemaBuilder.finish()
+
+        switch ArrowWriter().writeFile(ArrowWriter.Info(.recordbatch, schema: schema, batches: batches)) {
+        case .success(let data): try data.write(to: arrowURL)
+        case .failure(let error): throw error
+        }
+    }
+
+    /// Converts an Arrow JSON field into the real arrow-swift `ArrowField`.
+    func decodeField(_ field: ArrowJSON.Field) throws -> ArrowField {
+        ArrowField(field.name, type: try decodeArrowType(field), isNullable: field.nullable)
+    }
+
+    private func validateFiles(arrowURL: URL, jsonURL: URL) throws {
+        let expected = try JSONDecoder().decode(
+            ArrowJSON.self, from: try Data(contentsOf: jsonURL))
+
+        let actual = try decodeArrowJSON(from: arrowURL)
+
+        guard expected.normalized() == actual.normalized() else {
+            throw ValidationError("Arrow file does not match JSON file")
+        }
+    }
+
+    private func convertArrowToJSON(arrowURL: URL, jsonURL: URL) throws {
+        let gold = try decodeArrowJSON(from: arrowURL)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted]
+        try encoder.encode(gold).write(to: jsonURL)
+    }
+}

--- a/Sources/ArrowJSONIntegrationTest/ArrowJSONIntegrationTest.swift
+++ b/Sources/ArrowJSONIntegrationTest/ArrowJSONIntegrationTest.swift
@@ -20,9 +20,9 @@ import Arrow
 import Foundation
 
 enum IntegrationMode: String, ExpressibleByArgument, CaseIterable {
-  case arrowToJson = "ARROW_TO_JSON"
-  case jsonToArrow = "JSON_TO_ARROW"
-  case validate = "VALIDATE"
+    case arrowToJson = "ARROW_TO_JSON"
+    case jsonToArrow = "JSON_TO_ARROW"
+    case validate = "VALIDATE"
 }
 
 @main


### PR DESCRIPTION
## What's Changed

Added an Arrow-JSON integration testing executable as discussed in #96. This includes an ArrowJSON struct for decoding and encoding the Arrow JSON test files.

Added a rule to .swiftlint.yml to ignore case statements in cyclomatic complexity checks.

Made some Arrow Type declarations public to support encoding and decoding.

Fix: ArrowReader now creates a null buffer of the length specified by the flatbuffers definition, instead of calculating it from the array length. This fixes a bug where a null buffer of full length would be created and allocated as zeros, making a non-null array become all-null.